### PR TITLE
gitignore .sass-cache

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,2 +1,3 @@
 temp
 dist
+.sass-cache


### PR DESCRIPTION
After `yeoman build` compiles sass, a `.sass-cache` directory is made. @github [recommends](https://github.com/github/gitignore/blob/master/Compass.gitignore) Compass projects ignore `.sass-cache`.  Lets ignore this directory in git. 

Partial fix of https://github.com/yeoman/generators/issues/10
