### PR TITLE
Fixed typo in require.js template

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -200,7 +200,7 @@ AppGenerator.prototype.requirejs = function requirejs() {
       '        bootstrap: \'vendor/bootstrap\'',
       '    },',
       '    shim: {',
-      '        boostrap: {',
+      '        bootstrap: {',
       '            deps: [\'jquery\'],',
       '            exports: \'jquery\'',
       '        }',


### PR DESCRIPTION
Hard to spot, broke loading of bootstrap.js due to the missing jquery dep.
