### PR TITLE
jQuery is required in non-AMD build for bootstrap.js

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -134,6 +134,12 @@ AppGenerator.prototype.writeIndex = function writeIndex() {
     '                <ul>'
   ];
 
+  if (!this.includeRequireJS) {
+    this.indexFile = this.appendScripts(this.indexFile, 'scripts/jquery.js', [
+      'components/jquery/jquery.js'
+    ]);
+  }
+
   if (this.compassBootstrap && !this.includeRequireJS) {
     // wire Twitter Bootstrap plugins
     this.indexFile = this.appendScripts(this.indexFile, 'scripts/plugins.js', [


### PR DESCRIPTION
Generating an app with Bootstrap, but w/o require.js fails at the moment because jQuery is missing.

I put it into the plugins.js, but I'm not sure if it should be included even without bootstrap.js, because it's included in the components.js regardless.
