### PR TITLE
Yeoman generator has incorrect path to sass-bootstrap

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -117,7 +117,7 @@ AppGenerator.prototype.bootstrapJs = function bootstrapJs() {
 
 AppGenerator.prototype.mainStylesheet = function mainStylesheet() {
   if (this.compassBootstrap) {
-    this.write('app/styles/main.scss', '@import \'sass-bootstrap/lib/bootstrap\';\n\n.hero-unit {\n    margin: 50px auto 0 auto;\n    width: 300px;\n}');
+    this.write('app/styles/main.scss', '@import \'../components/sass-bootstrap/lib/bootstrap\';\n\n.hero-unit {\n    margin: 50px auto 0 auto;\n    width: 300px;\n}');
   } else {
     this.write('app/styles/main.css', 'body {\n    background: #fafafa;\n}\n\n.hero-unit {\n    margin: 50px auto 0 auto;\n    width: 300px;\n}');
   }


### PR DESCRIPTION
Error via Compass: `error styles/main.scss (Line 1: File to import not found or unreadable: sass-bootstrap/lib/bootstrap.`

Perhaps there's a better way to reference bootstrap, but here's my initial solution.
