### PR TITLE
grunt-rev

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -171,9 +171,17 @@ module.exports = function (grunt) {
             }
         },<% } %>
         rev: {
-            dist: {
+            src: {
                 files: {
-                    src: ['.tmp/**/*.{js,css,png,jpg}']
+                    src: ['.tmp/**/*.{js,css}']
+                }
+            },
+            assets: {
+                files: {
+                    src: [
+                        '<%%= yeoman.app %>/images/**/*.{png,jpg,jpeg}',
+                        '<%%= yeoman.app %>/styles/fonts/**/*.*'
+                    ]
                 }
             }
         },
@@ -283,10 +291,11 @@ module.exports = function (grunt) {
         'test',
         'coffee',
         'compass:dist',
-        'rev',
+        'rev:src',
         'useminPrepare',<% if (includeRequireJS) { %>
         'requirejs',<% } %>
         'imagemin',
+        'rev:assets',
         'cssmin',
         'htmlmin',
         'concat',

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -170,6 +170,13 @@ module.exports = function (grunt) {
                 }
             }
         },<% } %>
+        rev: {
+            dist: {
+                files: {
+                    src: ['.tmp/**/*.{js,css,png,jpg}']
+                }
+            }
+        },
         useminPrepare: {
             html: '<%%= yeoman.app %>/index.html',
             options: {
@@ -276,6 +283,7 @@ module.exports = function (grunt) {
         'test',
         'coffee',
         'compass:dist',
+        'rev',
         'useminPrepare',<% if (includeRequireJS) { %>
         'requirejs',<% } %>
         'imagemin',

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -17,6 +17,7 @@
     "grunt-contrib-imagemin": "0.1.1",
     "grunt-contrib-livereload": "0.1.1",
     "grunt-bower-hooks": "~0.2.0",
+    "grunt-rev": "~0.1.0",
     "grunt-usemin": "~0.1.9",
     "grunt-regarde": "~0.1.1",<% if (includeRequireJS) { %>
     "grunt-requirejs": "~0.3.1",<% } %>


### PR DESCRIPTION
The build process should use grunt-rev to rename all files according to their content hash.

Note: Please check how this affects the "watch" task targets. I'm not sure if rev/prepareUsemin/usemin need to be called each time now, or if the existing logic continues to work correctly.
