### PR TITLE
Copying scripts/*.js files when requirejs is activated

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -235,7 +235,10 @@ module.exports = function (grunt) {
                     dest: '<%%= yeoman.dist %>',
                     src: [
                         '*.{ico,txt}',
-                        '.htaccess'
+                        '.htaccess'<% if (includeRequireJS) { %>,
+                        'scripts/**/*.js',
+                        '!scripts/main.js',
+                        '!scripts/vendor/require.js'<% } %>
                     ]
                 }]
             }


### PR DESCRIPTION
Will allow to require 'lately' scripts not concatenated by requirejs task, see [this issue](https://github.com/yeoman/yeoman/issues/934) and [this repo demonstrating the issue](https://github.com/fcamblor/yeoman-requirejs-grunt-build)

Note that this copy is only needed when flag `includeRequireJS` is true, otherwise, js files are all concatenated into main.js (see `uglify` task in that case).

I would like to filter vendor/bootstrap.js too, when sass for bootstrap is activated, but I didn't found the flag name used to test this case. If you can help me on this flag name, I can edit this PR to handle this case.
