### PR TITLE
Compile CoffeeScript from one-level subdirectories

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -118,7 +118,7 @@ module.exports = function (grunt) {
                     // require them into your main .coffee file
                     expand: true,
                     cwd: '<%%= yeoman.app %>/scripts',
-                    src: '*.coffee',
+                    src: '{,*/}*.coffee',
                     dest: '.tmp/scripts',
                     ext: '.js'
                 }]


### PR DESCRIPTION
RIght now files in `scripts/*/*.coffee` are watched but not compiled.

Got reminded by https://github.com/yeoman/generator-angular/pull/92
