### PR TITLE
fix coffee:test task

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -126,9 +126,10 @@ module.exports = function (grunt) {
             test: {
                 files: [{
                     expand: true,
-                    cwd: '.tmp/spec',
+                    cwd: 'test/spec',
                     src: '*.coffee',
-                    dest: 'test/spec'
+                    dest: '.tmp/spec',
+                    ext: '.js'
                 }]
             }
         },


### PR DESCRIPTION
**Step to reproduce:**
(assume yo + grunt-cli + bower installed globally)
- yo webapp
- npm install
- delete test/spec/test.js
- create test/spec/test.coffee:
  
  describe "Give it some context", ->
- grunt coffee:test

**Expected result:**

```
Running "coffee:test" (coffee) task
File .tmp/spec/test.js created.
Done, without errors.
```

**Actual result:**

```
Running "coffee:test" (coffee) task
Done, without errors.
```

No .tmp directory created
