### PR TITLE
Copy webp and gif images to dist/

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -41,7 +41,7 @@ module.exports = function (grunt) {
                     '<%%= yeoman.app %>/*.html',
                     '{.tmp,<%%= yeoman.app %>}/styles/{,*/}*.css',
                     '{.tmp,<%%= yeoman.app %>}/scripts/{,*/}*.js',
-                    '<%%= yeoman.app %>/images/{,*/}*.{png,jpg,jpeg,webp}'
+                    '<%%= yeoman.app %>/images/{,*/}*.{png,jpg,jpeg,gif,webp}'
                 ],
                 tasks: ['livereload']
             }
@@ -245,7 +245,8 @@ module.exports = function (grunt) {
                     dest: '<%%= yeoman.dist %>',
                     src: [
                         '*.{ico,txt}',
-                        '.htaccess'
+                        '.htaccess',
+                        'images/{,*/}*.{webp,gif}'
                     ]
                 }]
             }


### PR DESCRIPTION
Livereload watches `webp` already, but as imagemin doesn't handle it, it does not get copied over `dist/` in the build step. Also GIFs were ignored so far, but unfortunately it's still the best way for stupid reaction animations.
