### PR TITLE
Auto install dependencies

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var util = require('util');
 var path = require('path');
+var spawn = require('child_process').spawn;
 var yeoman = require('yeoman-generator');
 
 
@@ -25,7 +26,9 @@ function AppGenerator(args, options, config) {
   this.mainCoffeeFile = 'console.log "\'Allo from CoffeeScript!"';
 
   this.on('end', function () {
-    console.log('\nI\'m all done. Just run ' + 'npm install && bower install'.bold.yellow + ' to install the required dependencies.');
+    console.log('\n\nI\'m all done. Running ' + 'npm install & bower install'.bold.yellow + ' for you to install the required dependencies. If this fails, try running the command yourself.\n\n');
+    spawn('npm', ['install'], { stdio: 'inherit' });
+    spawn('bower', ['install'], { stdio: 'inherit' });
   });
 
   this.pkg = JSON.parse(this.readFileAsString(path.join(__dirname, '../package.json')));


### PR DESCRIPTION
Many users have voiced concern of there being too many commands to get started. The original intention of not automatically installing deps after scaffolding was for clearity of what was happening. Since users would think a npm bug was a bug with Yeoman. Seeing as this has helped nothing, and people keep opening invalid issues like crazy, I don't think that is an argument anymore.

After thinking about this for a while, I've come to the conclusion that we can do both clearity and ease of use, by doing it automatically, but being totally clear about it. That means showing a clear message as shown below and documenting it. After all, Yeoman is about making front-end development less painful.

@addyosmani @sleeper @btford @passy wdyt?

_this also parallizes both commands, so it's faster than before._

![Screen Shot 2013-03-17 at 16 04 58](https://f.cloud.github.com/assets/170270/268206/50d2198c-8f14-11e2-932c-aa570d675c37.png)
