### PR TITLE
Prevent the uglify task from overriding usemin

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -172,15 +172,12 @@ module.exports = function (grunt) {
                 }
             }
         },<% } else { %>
-        uglify: {
-            dist: {
-                files: {
-                    '<%%= yeoman.dist %>/scripts/main.js': [
-                        '<%%= yeoman.app %>/scripts/{,*/}*.js'
-                    ],
-                }
-            }
-        },<% } %>
+        // not enabled since usemin task does concat and uglify
+        // check index.html to edit your build targets
+        // enable this task if you prefer defining your build targets here
+        /*uglify: {
+            dist: {}
+        },*/<% } %>
         useminPrepare: {
             html: '<%%= yeoman.app %>/index.html',
             options: {


### PR DESCRIPTION
Comment out the uglify task since we define our build targets by using the usemin task in index.html.

Fixes #30.
