### PR TITLE
Added `generator-mocha` to `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "yeoman-generator": "~0.10.4",
     "cheerio": "~0.10.8"
   },
+  "peerDependencies": {
+    "generator-mocha": "~0.1.1"
+  },
   "devDependencies": {
     "mocha": "~1.9.0"
   },


### PR DESCRIPTION
Added generator-mocha dependency into npm peerDependencies as discussed in yeoman/yo#19. This is in preparation for removing default generators from `yo`.

If you want to test it out locally, you can install it directly from my branch using this command:

``` bash
$ npm install https://nodeload.github.com/danielmcormond/generator-webapp/tar.gz/peer-dependencies
```
