### PR TITLE
Use grunt-contrib-watch for livereload

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -1,6 +1,7 @@
 // Generated on <%= (new Date).toISOString().split('T')[0] %> using <%= pkg.name %> <%= pkg.version %>
 'use strict';
-var lrSnippet = require('grunt-contrib-livereload/lib/utils').livereloadSnippet;
+var LIVERELOAD_PORT = 35729;
+var lrSnippet = require('connect-livereload')({port: LIVERELOAD_PORT});
 var mountFolder = function (connect, dir) {
     return connect.static(require('path').resolve(dir));
 };
@@ -24,6 +25,9 @@ module.exports = function (grunt) {
     grunt.initConfig({
         yeoman: yeomanConfig,
         watch: {
+            options: {
+              spawn: false
+            },
             coffee: {
                 files: ['<%%= yeoman.app %>/scripts/{,*/}*.coffee'],
                 tasks: ['coffee:dist']
@@ -37,13 +41,15 @@ module.exports = function (grunt) {
                 tasks: ['compass:server']
             },
             livereload: {
+                options: {
+                    livereload: LIVERELOAD_PORT
+                },
                 files: [
                     '<%%= yeoman.app %>/*.html',
                     '{.tmp,<%%= yeoman.app %>}/styles/{,*/}*.css',
                     '{.tmp,<%%= yeoman.app %>}/scripts/{,*/}*.js',
                     '<%%= yeoman.app %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
-                ],
-                tasks: ['livereload']
+                ]
             }
         },
         connect: {
@@ -56,9 +62,9 @@ module.exports = function (grunt) {
                 options: {
                     middleware: function (connect) {
                         return [
-                            lrSnippet,
                             mountFolder(connect, '.tmp'),
-                            mountFolder(connect, 'app')
+                            mountFolder(connect, 'app'),
+                            lrSnippet
                         ];
                     }
                 }
@@ -317,8 +323,6 @@ module.exports = function (grunt) {
         }<% } %>
     });
 
-    grunt.renameTask('regarde', 'watch');
-
     grunt.registerTask('server', function (target) {
         if (target === 'dist') {
             return grunt.task.run(['build', 'open', 'connect:dist:keepalive']);
@@ -327,7 +331,6 @@ module.exports = function (grunt) {
         grunt.task.run([
             'clean:server',
             'concurrent:server',
-            'livereload-start',
             'connect:livereload',
             'open',
             'watch'

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -15,18 +15,18 @@
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-htmlmin": "~0.1.3",
     "grunt-contrib-imagemin": "~0.1.3",
-    "grunt-contrib-livereload": "~0.1.2",<% if (testFramework === 'jasmine') { %>
+    "grunt-contrib-watch": "~0.4.0",<% if (testFramework === 'jasmine') { %>
     "grunt-contrib-jasmine": "~0.4.2",<% } %>
     "grunt-bower-requirejs": "~0.4.1",
     "grunt-rev": "~0.1.0",
-    "grunt-usemin": "~0.1.10",
-    "grunt-regarde": "~0.1.1",<% if (includeRequireJS) { %>
+    "grunt-usemin": "~0.1.10",<% if (includeRequireJS) { %>
     "grunt-requirejs": "~0.3.5",<% } if (testFramework === 'mocha') {  %>
     "grunt-mocha": "~0.3.0",<% } %>
     "grunt-open": "~0.2.0",
     "grunt-svgmin": "~0.1.0",
     "grunt-concurrent": "~0.1.0",
-    "matchdep": "~0.1.1"
+    "matchdep": "~0.1.1",
+    "connect-livereload": "~0.1.1"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
https://github.com/gruntjs/grunt-contrib-watch#live-reloading

grunt-contrib-watch got support for livereload. We should convert all generators over to it asap.

<del>This is just a start as I was stopped by a potential [bug](https://github.com/intesso/connect-livereload/issues/1) in connect-livereload. @kevva @passy would you be able to look into it?</del>
