### PR TITLE
Minor fixes when sass for twitter bootstrap is not installed

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -130,7 +130,6 @@ AppGenerator.prototype.mainStylesheet = function mainStylesheet() {
   } else {
     this.write('app/styles/main.css', 'body {\n    background: #fafafa;\n    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;\n    color: #333;\n}\n\n.hero-unit {\n    margin: 50px auto 0 auto;\n    width: 300px;\n    font-size: 18px;\n    font-weight: 200;\n    line-height: 30px;\n    background-color: #eee;\n    border-radius: 6px;\n    padding: 60px;\n}\n\n.hero-unit h1 {\n    font-size: 60px;\n    line-height: 1;\n    letter-spacing: -1px;\n}');
     this.write('app/styles/main.scss', 'body {\n    background: #fafafa;\n    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;\n    color: #333;\n}\n\n.hero-unit {\n    margin: 50px auto 0 auto;\n    width: 300px;\n    font-size: 18px;\n    font-weight: 200;\n    line-height: 30px;\n    background-color: #eee;\n    border-radius: 6px;\n    padding: 60px;\n}\n\n.hero-unit h1 {\n    font-size: 60px;\n    line-height: 1;\n    letter-spacing: -1px;\n}');
-    this.write('app/styles/main.sass', 'body\n    background: #fafafa\n    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif\n    color: #333\n\n.hero-unit\n    margin: 50px auto 0 auto\n    width: 300px\n    font-size: 18px\n    font-weight: 200\n    line-height: 30px\n    background-color: #eee\n    border-radius: 6px\n    padding: 60px\n\n.hero-unit h1\n    font-size: 60px\n    line-height: 1\n    letter-spacing: -1px');
   }
 };
 

--- a/app/index.js
+++ b/app/index.js
@@ -128,7 +128,7 @@ AppGenerator.prototype.mainStylesheet = function mainStylesheet() {
   if (this.compassBootstrap) {
     this.write('app/styles/main.scss', '$iconSpritePath: "../images/glyphicons-halflings.png";\n$iconWhiteSpritePath: "../images/glyphicons-halflings-white.png";\n\n@import \'sass-bootstrap/lib/bootstrap\';\n\n.hero-unit {\n    margin: 50px auto 0 auto;\n    width: 300px;\n}');
   } else {
-    this.write('app/styles/main.css', 'body {\n    background: #fafafa;\n    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;\n    color: #333;\n}\n\n.hero-unit {\n    margin: 50px auto 0 auto;\n    width: 300px;\n    font-size: 18px;\n    font-weight: 200;\n    line-height: 30px;\n    background-color: #eee;\n    border-radius: 6px;\n    padding: 60px;\n}\n\n.hero-unit h1 {\n    font-size: 60px;\n    line-height: 1;\n    letter-spacing: -1px;\n}');
+    this.copy('main.css', 'app/styles/main.css');
   }
 };
 
@@ -237,7 +237,7 @@ AppGenerator.prototype.requirejs = function requirejs() {
       '    }',
       '});',
       '',
-      'require('+requiredScripts+', function (app, $) {',
+      'require(' + requiredScripts + ', function (app, $) {',
       '    \'use strict\';',
       '    // use app here',
       '    console.log(app);',

--- a/app/index.js
+++ b/app/index.js
@@ -126,7 +126,7 @@ AppGenerator.prototype.bootstrapJs = function bootstrapJs() {
 
 AppGenerator.prototype.mainStylesheet = function mainStylesheet() {
   if (this.compassBootstrap) {
-    this.write('app/styles/main.scss', '$iconSpritePath: "../images/glyphicons-halflings.png";\n$iconWhiteSpritePath: "../images/glyphicons-halflings-white.png";\n\n@import \'sass-bootstrap/lib/bootstrap\';\n\n.hero-unit {\n    margin: 50px auto 0 auto;\n    width: 300px;\n}');
+    this.copy('main.scss', 'app/styles/main.scss');
   } else {
     this.copy('main.css', 'app/styles/main.css');
   }

--- a/app/index.js
+++ b/app/index.js
@@ -128,13 +128,15 @@ AppGenerator.prototype.mainStylesheet = function mainStylesheet() {
   if (this.compassBootstrap) {
     this.write('app/styles/main.scss', '$iconSpritePath: "../images/glyphicons-halflings.png";\n$iconWhiteSpritePath: "../images/glyphicons-halflings-white.png";\n\n@import \'sass-bootstrap/lib/bootstrap\';\n\n.hero-unit {\n    margin: 50px auto 0 auto;\n    width: 300px;\n}');
   } else {
-    this.write('app/styles/main.css', 'body {\n    background: #fafafa;\n}\n\n.hero-unit {\n    margin: 50px auto 0 auto;\n    width: 300px;\n}');
+    this.write('app/styles/main.css', 'body {\n    background: #fafafa;\n    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;\n    color: #333;\n}\n\n.hero-unit {\n    margin: 50px auto 0 auto;\n    width: 300px;\n    font-size: 18px;\n    font-weight: 200;\n    line-height: 30px;\n    background-color: #eee;\n    border-radius: 6px;\n    padding: 60px;\n}\n\n.hero-unit h1 {\n    font-size: 60px;\n    line-height: 1;\n    letter-spacing: -1px;\n}');
+    this.write('app/styles/main.scss', 'body {\n    background: #fafafa;\n    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;\n    color: #333;\n}\n\n.hero-unit {\n    margin: 50px auto 0 auto;\n    width: 300px;\n    font-size: 18px;\n    font-weight: 200;\n    line-height: 30px;\n    background-color: #eee;\n    border-radius: 6px;\n    padding: 60px;\n}\n\n.hero-unit h1 {\n    font-size: 60px;\n    line-height: 1;\n    letter-spacing: -1px;\n}');
+    this.write('app/styles/main.sass', 'body\n    background: #fafafa\n    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif\n    color: #333\n\n.hero-unit\n    margin: 50px auto 0 auto\n    width: 300px\n    font-size: 18px\n    font-weight: 200\n    line-height: 30px\n    background-color: #eee\n    border-radius: 6px\n    padding: 60px\n\n.hero-unit h1\n    font-size: 60px\n    line-height: 1\n    letter-spacing: -1px');
   }
 };
 
 AppGenerator.prototype.writeIndex = function writeIndex() {
   // prepare default content text
-  var defaults = ['HTML5 Boilerplate', 'Twitter Bootstrap'];
+  var defaults = ['HTML5 Boilerplate'];
   var contentText = [
     '        <div class="container">',
     '            <div class="hero-unit">',
@@ -156,6 +158,10 @@ AppGenerator.prototype.writeIndex = function writeIndex() {
       sourceFileList: ['scripts/hello.js'],
       searchPath: '.tmp'
     });
+  }
+
+  if (this.compassBootstrap) {
+    defaults.push('Twitter Bootstrap');
   }
 
   if (this.compassBootstrap && !this.includeRequireJS) {
@@ -203,6 +209,9 @@ AppGenerator.prototype.writeIndex = function writeIndex() {
 
 // TODO(mklabs): to be put in a subgenerator like rjs:app
 AppGenerator.prototype.requirejs = function requirejs() {
+  var requiredScripts = (this.compassBootstrap) ? '[\'app\', \'jquery\', \'bootstrap\']' : '[\'app\', \'jquery\']';
+  var bootstrapPath = (this.compassBootstrap) ? '        bootstrap: \'vendor/bootstrap\'\n    },' : '    },';
+
   if (this.includeRequireJS) {
     this.indexFile = this.appendScripts(this.indexFile, 'scripts/main.js', ['bower_components/requirejs/require.js'], {
       'data-main': 'scripts/main'
@@ -221,8 +230,7 @@ AppGenerator.prototype.requirejs = function requirejs() {
       'require.config({',
       '    paths: {',
       '        jquery: \'../bower_components/jquery/jquery\',',
-      '        bootstrap: \'vendor/bootstrap\'',
-      '    },',
+      bootstrapPath,
       '    shim: {',
       '        bootstrap: {',
       '            deps: [\'jquery\'],',
@@ -231,7 +239,7 @@ AppGenerator.prototype.requirejs = function requirejs() {
       '    }',
       '});',
       '',
-      'require([\'app\', \'jquery\', \'bootstrap\'], function (app, $) {',
+      'require('+requiredScripts+', function (app, $) {',
       '    \'use strict\';',
       '    // use app here',
       '    console.log(app);',

--- a/app/index.js
+++ b/app/index.js
@@ -129,7 +129,6 @@ AppGenerator.prototype.mainStylesheet = function mainStylesheet() {
     this.write('app/styles/main.scss', '$iconSpritePath: "../images/glyphicons-halflings.png";\n$iconWhiteSpritePath: "../images/glyphicons-halflings-white.png";\n\n@import \'sass-bootstrap/lib/bootstrap\';\n\n.hero-unit {\n    margin: 50px auto 0 auto;\n    width: 300px;\n}');
   } else {
     this.write('app/styles/main.css', 'body {\n    background: #fafafa;\n    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;\n    color: #333;\n}\n\n.hero-unit {\n    margin: 50px auto 0 auto;\n    width: 300px;\n    font-size: 18px;\n    font-weight: 200;\n    line-height: 30px;\n    background-color: #eee;\n    border-radius: 6px;\n    padding: 60px;\n}\n\n.hero-unit h1 {\n    font-size: 60px;\n    line-height: 1;\n    letter-spacing: -1px;\n}');
-    this.write('app/styles/main.scss', 'body {\n    background: #fafafa;\n    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;\n    color: #333;\n}\n\n.hero-unit {\n    margin: 50px auto 0 auto;\n    width: 300px;\n    font-size: 18px;\n    font-weight: 200;\n    line-height: 30px;\n    background-color: #eee;\n    border-radius: 6px;\n    padding: 60px;\n}\n\n.hero-unit h1 {\n    font-size: 60px;\n    line-height: 1;\n    letter-spacing: -1px;\n}');
   }
 };
 

--- a/app/templates/main.css
+++ b/app/templates/main.css
@@ -1,0 +1,22 @@
+body {
+    background: #fafafa;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    color: #333;
+}
+
+.hero-unit {
+    margin: 50px auto 0 auto;
+    width: 300px;
+    font-size: 18px;
+    font-weight: 200;
+    line-height: 30px;
+    background-color: #eee;
+    border-radius: 6px;
+    padding: 60px;
+}
+
+.hero-unit h1 {
+    font-size: 60px;
+    line-height: 1;
+    letter-spacing: -1px;
+}

--- a/app/templates/main.scss
+++ b/app/templates/main.scss
@@ -1,0 +1,9 @@
+$iconSpritePath: "../images/glyphicons-halflings.png";
+$iconWhiteSpritePath: "../images/glyphicons-halflings-white.png";
+
+@import 'sass-bootstrap/lib/bootstrap';
+
+.hero-unit {
+    margin: 50px auto 0 auto;
+    width: 300px;
+}


### PR DESCRIPTION
**EDITED AND REWRITTEN**

I made a stupid mistake with one of the suggested revisions in this original pull request, which then embarrassingly took two commits to rectify, so I'm rewriting this pull request discussion from scratch that totally ignores that whole suggested revision (which is jettisoned as of the newer commits). I'm really sorry about the commits -- I can squash all of them and push again, but I wasn't sure if that was good practice once the initial pull request has been established. So if I can ever recover face after making my blunders public, here is a pull request that fixes a couple of minor issues which crop up on the webapp generator if sass for twitter bootstrap is not selected on the CLI during scaffolding --

This pull request addresses two issues/bugs:

1 - If SASS for Bootstrap is not installed but RequireJS _is_ installed, two runtime errors would be thrown because bootstrap.js was still left in the code as a required module even though the file was not copied into the folders (thus tripping a 404 error and a RequireJS error). This has been fixed.

2 - If SASS for Bootstrap is not installed, the default index.html still had a line in the `<ul>` which indicated that Bootstrap had been installed. I added an `if` conditional to index.js so this list item only appears if Bootstrap was actually installed.

Additionally, the main.css file generated if SASS for Bootstrap was not installed has more styling now to more closely resemble the Bootstrap version, for a more polished appearance.

The first two items are real fixes, the third is just cosmetic. My alterations seem to fix the issues from my end. Please add a comment if there are any questions or if what I'm talking about makes no sense. Thanks.
