### PR TITLE
Revise confirmation messages for new prompt

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -54,13 +54,11 @@ AppGenerator.prototype.askFor = function askFor() {
     name: 'compassBootstrap',
     message: 'Would you like to include Twitter Bootstrap for Sass?',
     default: true,
-    warning: 'Yes: All Twitter Bootstrap files will be placed into the styles directory.'
   },
   {
     name: 'includeRequireJS',
     message: 'Would you like to include RequireJS (for AMD support)?',
     default: true,
-    warning: 'Yes: RequireJS will be placed into the JavaScript vendor directory.'
   }];
 
   this.prompt(prompts, function (err, props) {
@@ -72,6 +70,13 @@ AppGenerator.prototype.askFor = function askFor() {
     // we change a bit this way of doing to automatically do this in the self.prompt() method.
     this.compassBootstrap = props.compassBootstrap;
     this.includeRequireJS = props.includeRequireJS;
+
+    if (this.compassBootstrap) {
+      console.log('All Twitter Bootstrap files will be placed into the styles directory.');
+    }
+    if (this.includeRequireJS) {
+      console.log('RequireJS will be placed into the JavaScript vendor directory.');
+    }
 
     cb();
   }.bind(this));


### PR DESCRIPTION
With the read library, `warning` was a message based on successful user input. With the new prompt it seems to be an alias of prompt's `message`, which is an explanation of why your input didn't pass validation. 

This switches the confirmation messages to normal `console.log`s.

Shout out to #58.
