### PR TITLE
Fix for livereload failure on newly generated webapps.

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -62,9 +62,9 @@ module.exports = function (grunt) {
                 options: {
                     middleware: function (connect) {
                         return [
+                            lrSnippet,
                             mountFolder(connect, '.tmp'),
-                            mountFolder(connect, yeomanConfig.app),
-                            lrSnippet
+                            mountFolder(connect, yeomanConfig.app)
                         ];
                     }
                 }

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -26,7 +26,7 @@
     "grunt-svgmin": "~0.1.0",
     "grunt-concurrent": "~0.1.0",
     "matchdep": "~0.1.1",
-    "connect-livereload": "~0.1.1"
+    "connect-livereload": "~0.1.4"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
Upgraded connect-livereload and re-ordered the middleware for the lrSnippet to
fix the livereload functionality per issue https://github.com/yeoman/generator-webapp/issues/63 .
