### PR TITLE
Update project and template jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,5 @@
 {
 	"node": true,
-	"es5": true,
 	"esnext": true,
 	"bitwise": false,
 	"curly": false,

--- a/app/templates/jshintrc
+++ b/app/templates/jshintrc
@@ -1,7 +1,6 @@
 {
     "node": true,
     "browser": true,
-    "es5": true,
     "esnext": true,
     "bitwise": true,
     "camelcase": true,


### PR DESCRIPTION
This updates the project template `jshintrc` to the same standards as the repo `.jshintrc`. Also removes the now default `es5` rule.
