### PR TITLE
Added support for autoprefixer

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -50,6 +50,12 @@ AppGenerator.prototype.askFor = function askFor() {
     name: 'includeRequireJS',
     message: 'Would you like to include RequireJS (for AMD support)?',
     default: true
+  },
+  {
+    type: 'confirm',
+    name: 'autoprefixer',
+    message: 'Would you like to use autoprefixer for your CSS?',
+    default: false
   }];
 
   this.prompt(prompts, function (props) {
@@ -57,6 +63,7 @@ AppGenerator.prototype.askFor = function askFor() {
     // we change a bit this way of doing to automatically do this in the self.prompt() method.
     this.compassBootstrap = props.compassBootstrap;
     this.includeRequireJS = props.includeRequireJS;
+    this.autoprefixer = props.autoprefixer;
 
     cb();
   }.bind(this));

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -20,6 +20,7 @@
     "grunt-contrib-watch": "~0.4.0",<% if (testFramework === 'jasmine') { %>
     "grunt-contrib-jasmine": "~0.4.2",<% } %>
     "grunt-rev": "~0.1.0",
+    "grunt-autoprefixer": "~0.1.20130516",
     "grunt-usemin": "~0.1.10",<% if (testFramework === 'mocha') {  %>
     "grunt-mocha": "~0.3.0",<% } %>
     "grunt-open": "~0.2.0",

--- a/test/test.js
+++ b/test/test.js
@@ -43,7 +43,8 @@ describe('Webapp generator test', function () {
 
     helpers.mockPrompt(this.webapp, {
       'compassBootstrap': 'Y',
-      'includeRequireJS': 'N'
+      'includeRequireJS': 'N',
+      'autoprefixer': 'N'
     });
 
     this.webapp.options['skip-install'] = true;
@@ -68,7 +69,8 @@ describe('Webapp generator test', function () {
 
     helpers.mockPrompt(this.webapp, {
       'compassBootstrap': 'Y',
-      'includeRequireJS': 'Y'
+      'includeRequireJS': 'Y',
+      'autoprefixer': 'N'
     });
 
     this.webapp.options['skip-install'] = true;


### PR DESCRIPTION
Before I lose track of it, I pulled out my autoprefixer setup for #62.

Currently, this only works for files processed by compass, because it only runs on files in `.tmp`. In order to make sure files aren't processed twice by autoprefxier, we would have to restructure the tasks a little to make it work for plain CSS files. OTOH, I would argue if you use plain CSS, you might not want any magic at all.

But let's discuss those details post-1.0. :)

(fix #62)
