### PR TITLE
Keep compass actions in compass task

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -166,7 +166,11 @@ module.exports = function (grunt) {
                 httpGeneratedImagesPath: '/images/generated',
                 relativeAssets: false
             },
-            dist: {},
+            dist: {
+                options: {
+                    generatedImagesDir: '<%%= yeoman.dist %>/images/generated'
+                }
+            },
             server: {
                 options: {
                     debugInfo: true
@@ -292,13 +296,6 @@ module.exports = function (grunt) {
                         '.htaccess',
                         'images/{,*/}*.{webp,gif}',
                         'styles/fonts/*'
-                    ]
-                }, {
-                    expand: true,
-                    cwd: '.tmp/images',
-                    dest: '<%%= yeoman.dist %>/images',
-                    src: [
-                        'generated/*'
                     ]
                 }]
             }


### PR DESCRIPTION
Compass generated images are handled by the Compass task and the copy task. This brings them all under the compass task.

Side note, generated images in the current gruntfile and after this PR aren't touched by imagemin.
