### PR TITLE
add jQuery globals to jshintrc

### DIFF
--- a/app/templates/jshintrc
+++ b/app/templates/jshintrc
@@ -17,5 +17,6 @@
     "unused": true,
     "strict": true,
     "trailing": true,
-    "smarttabs": true
+    "smarttabs": true,
+    "jquery": true
 }


### PR DESCRIPTION
I had to manually add it to make jshint play nice with $.
Would be nice if it's included out of the box, I think.
