### PR TITLE
Fix duplicate CSS with autoprefixer

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -35,20 +35,19 @@ module.exports = function (grunt) {
             },
             compass: {
                 files: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
-                tasks: ['compass:server'<% if (autoprefixer) { %>, 'autoprefixer' <% } %>]
-            },<% if (autoprefixer) { %>
+                tasks: ['compass:server'<% if (autoprefixer) { %>, 'autoprefixer'<% } %>]
+            },
             styles: {
                 files: ['<%%= yeoman.app %>/styles/{,*/}*.css'],
-                tasks: ['copy:styles', 'autoprefixer']
-            },<% } %>
+                tasks: ['copy:styles'<% if (autoprefixer) { %>, 'autoprefixer'<% } %>]
+            },
             livereload: {
                 options: {
                     livereload: LIVERELOAD_PORT
                 },
                 files: [
-                    '<%%= yeoman.app %>/*.html',<% if (autoprefixer) { %>
-                    '.tmp/styles/{,*/}*.css',<% } else { %>
-                    '{.tmp,<%%= yeoman.app %>}/styles/{,*/}*.css',<% } %>
+                    '<%%= yeoman.app %>/*.html',
+                    '.tmp/styles/{,*/}*.css',
                     '{.tmp,<%%= yeoman.app %>}/scripts/{,*/}*.js',
                     '<%%= yeoman.app %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
                 ]
@@ -320,29 +319,29 @@ module.exports = function (grunt) {
                         'styles/fonts/*'
                     ]
                 }]
-            }<% if (autoprefixer) { %>,
+            },
             styles: {
                 expand: true,
                 dot: true,
                 cwd: '<%%= yeoman.app %>/styles',
                 dest: '.tmp/styles/',
                 src: '{,*/}*.css'
-            }<% } %>
+            }
         },
         concurrent: {
             server: [
                 'compass',
-                'coffee:dist'<% if (autoprefixer) { %>,
-                'copy:styles'<% } %>
+                'coffee:dist',
+                'copy:styles'
             ],
             test: [
-                'coffee'<% if (autoprefixer) { %>,
-                'copy:styles'<% } %>
+                'coffee',
+                'copy:styles'
             ],
             dist: [
                 'coffee',
-                'compass',<% if (autoprefixer) { %>
-                'copy:styles',<% } %>
+                'compass',
+                'copy:styles',
                 'imagemin',
                 'svgmin',
                 'htmlmin'

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -10,7 +10,7 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
-        <!-- build:css({.tmp,app}) styles/main.css -->
+        <!-- build:css(.tmp) styles/main.css -->
         <link rel="stylesheet" href="styles/main.css">
         <!-- endbuild -->
         <!-- build:js scripts/vendor/modernizr.js -->


### PR DESCRIPTION
Fixes #108

> Due to the way the usemin block was set up, it would concat and minify both the
> non-prefixed and the prefixed CSS file. Now, depending on whether you enable
> autoprefixer or not, the usemin search path is adjusted and the snippet is
> programmatically inserted into the index.html template.

/cc @stephenplusplus @addyosmani Could you take a look that I did not introduce another silly mistake?
