### PR TITLE
Drop Autoprefixer prompt, make it a default

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -50,10 +50,6 @@ AppGenerator.prototype.askFor = function askFor() {
       name: 'RequireJS',
       value: 'includeRequireJS',
       checked: true
-    }, {
-      name: 'Autoprefixer for your CSS',
-      value: 'autoprefixer',
-      checked: true
     }]
   }];
 
@@ -64,7 +60,6 @@ AppGenerator.prototype.askFor = function askFor() {
     // we change a bit this way of doing to automatically do this in the self.prompt() method.
     this.compassBootstrap = features.indexOf('compassBootstrap') !== -1;
     this.includeRequireJS = features.indexOf('includeRequireJS') !== -1;
-    this.autoprefixer = features.indexOf('autoprefixer') !== -1;
 
     cb();
   }.bind(this));

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -19,8 +19,8 @@
     "grunt-contrib-imagemin": "~0.1.3",
     "grunt-contrib-watch": "~0.4.0",<% if (testFramework === 'jasmine') { %>
     "grunt-contrib-jasmine": "~0.4.2",<% } %>
-    "grunt-rev": "~0.1.0",<% if (autoprefixer) { %>
-    "grunt-autoprefixer": "~0.1.20130516",<% } %>
+    "grunt-rev": "~0.1.0",
+    "grunt-autoprefixer": "~0.1.20130516",
     "grunt-usemin": "~0.1.10",<% if (testFramework === 'mocha') {  %>
     "grunt-mocha": "~0.3.0",<% } %>
     "grunt-open": "~0.2.0",


### PR DESCRIPTION
We haven't received many (if any) reports of issues with Autoprefixing since we introduced it. This PR drops the prompt for the feature and treats it as a default. 

Do let me know if I missed anything :)
