### PR TITLE
Add `yo` as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "cheerio": "~0.10.8"
   },
   "peerDependencies": {
-    "generator-mocha": "~0.1.1"
+    "generator-mocha": "~0.1.1",
+    "yo": ">=1.0.0-rc.1.1"
   },
   "devDependencies": {
     "mocha": "~1.9.0"


### PR DESCRIPTION
/re https://github.com/yeoman/generator/issues/305

Since `yo` specifies `grunt-cli` and `bower` as peerDependencies, this should allow a `npm install -g generator-webapp` to install all three of them globally. Is that right or am I missing something?

/cc @addyosmani @sindresorhus
