### PR TITLE
Allow font files in sub-folders

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -229,7 +229,7 @@ module.exports = function (grunt) {
                         '<%%= yeoman.dist %>/scripts/{,*/}*.js',
                         '<%%= yeoman.dist %>/styles/{,*/}*.css',
                         '<%%= yeoman.dist %>/images/{,*/}*.{png,jpg,jpeg,gif,webp}',
-                        '<%%= yeoman.dist %>/styles/fonts/*'
+                        '<%%= yeoman.dist %>/styles/fonts/{,*/}*.*'
                     ]
                 }
             }
@@ -316,7 +316,7 @@ module.exports = function (grunt) {
                         '*.{ico,png,txt}',
                         '.htaccess',
                         'images/{,*/}*.{webp,gif}',
-                        'styles/fonts/*'
+                        'styles/fonts/{,*/}*.*'
                     ]
                 }]
             },


### PR DESCRIPTION
Hello Guys

I organize my fonts as well:
![image](https://f.cloud.github.com/assets/736728/932779/6c0e746c-0047-11e3-9ba8-33a16830329b.png)

And the actual configuration breaks the build.

```
Warning: Unable to read "dist/styles/fonts/bebasneue" file (Error code: EISDIR).
 Use --force to continue.
Error: EISDIR, illegal operation on a directory
    at Object.fs.readSync (fs.js:476:19)
    at Object.fs.readSync (c:\wamp\www\omo-aba\node_modules\grunt\node_modules\r
imraf\node_modules\graceful-fs\graceful-fs.js:303:23)
    at Object.fs.readFileSync (fs.js:315:28)
    at Object.file.read (c:\wamp\www\omo-aba\node_modules\grunt\lib\grunt\file.j
s:223:19)
    at md5 (c:\wamp\www\omo-aba\node_modules\grunt-rev\tasks\rev.js:20:28)
    at c:\wamp\www\omo-aba\node_modules\grunt-rev\tasks\rev.js:34:20
    at Array.forEach (native)
    at c:\wamp\www\omo-aba\node_modules\grunt-rev\tasks\rev.js:32:20
    at Array.forEach (native)
    at Object.<anonymous> (c:\wamp\www\omo-aba\node_modules\grunt-rev\tasks\rev.
js:31:16)

Aborted due to warnings.
```

---

> That's All folks :pig: 
