### PR TITLE
add grunt-bower-install. closes #121.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -135,12 +135,26 @@ AppGenerator.prototype.writeIndex = function writeIndex() {
     '                <ul>'
   ];
 
+  var bowerInstallText
+    = '\n        <!-- build:js scripts/vendor.js -->'
+    + '\n        <!-- bower:js -->'
+    + (this.includeModernizr
+        ?
+      '\n        <script src="bower_components/modernizr/modernizr.js"></script>'
+        :
+      '')
+    + '\n        <script src="bower_components/jquery/jquery.js"></script>'
+    + '\n        <!-- endbower -->'
+    + '\n        <!-- endbuild -->'
+    + '\n';
+
   this.indexFile = this.readFileAsString(path.join(this.sourceRoot(), 'index.html'));
   this.indexFile = this.engine(this.indexFile, this);
 
   if (!this.includeRequireJS) {
+    this.indexFile = this.append(this.indexFile, 'body', bowerInstallText);
+
     this.indexFile = this.appendScripts(this.indexFile, 'scripts/main.js', [
-      'bower_components/jquery/jquery.js',
       'scripts/main.js'
     ]);
 

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -218,6 +218,12 @@ module.exports = function (grunt) {
                 }
             }
         },<% } else { %>
+        'bower-install': {
+            app: {
+                html: '<%%= yeoman.app %>/index.html',
+                ignorePath: '<%%= yeoman.app %>/'
+            }
+        },
         // not enabled since usemin task does concat and uglify
         // check index.html to edit your build targets
         // enable this task if you prefer defining your build targets here

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -15,8 +15,8 @@
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-htmlmin": "~0.1.3",<% if (includeRequireJS) { %>
     "grunt-bower-requirejs": "~0.4.1",
-    "grunt-contrib-requirejs": "~0.4.0",<% } %><% if (includeModernizr) { %>
-    "grunt-modernizr": "~0.3.0",<% } %>
+    "grunt-contrib-requirejs": "~0.4.0",<% } else { %>
+    "grunt-bower-install": "~0.5.0",<% } %>
     "grunt-contrib-imagemin": "~0.1.3",
     "grunt-contrib-watch": "~0.4.0",<% if (testFramework === 'jasmine') { %>
     "grunt-contrib-jasmine": "~0.4.2",<% } %>
@@ -24,7 +24,8 @@
     "grunt-autoprefixer": "~0.1.20130516",
     "grunt-usemin": "~0.1.10",<% if (testFramework === 'mocha') {  %>
     "grunt-mocha": "~0.3.0",<% } %>
-    "grunt-open": "~0.2.0",
+    "grunt-open": "~0.2.0",<% if (includeModernizr) { %>
+    "grunt-modernizr": "~0.3.0",<% } %>
     "grunt-svgmin": "~0.1.0",
     "grunt-concurrent": "~0.1.0",
     "matchdep": "~0.1.1",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,10 +12,7 @@
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
         <!-- build:css(.tmp) styles/main.css -->
         <link rel="stylesheet" href="styles/main.css">
-        <!-- endbuild --><% if (includeModernizr) { %>
-        <!-- build:js scripts/vendor/modernizr.js -->
-        <script src="bower_components/modernizr/modernizr.js"></script>
-        <!-- endbuild --><% } %>
+        <!-- endbuild -->
     </head>
     <body>
         <!--[if lt IE 7]>


### PR DESCRIPTION
This is an initial PR to add in `grunt-bower-install`, should we decide we want it in cases where a user opts to not use RequireJS.

Something unfortunate is I had to move Modernizr to a new `scripts/vendor.js` usemin block. The block in the generated `index.html` will look like this:

``` html
<!-- build:js scripts/vendor.js -->
<!-- bower:js -->
<script src="bower_components/modernizr/modernizr.js"></script>
<script src="bower_components/jquery/jquery.js"></script>
<!-- endbower -->
<!-- endbuild -->
```

Anything inside of the `<!-- bower:js -->` block will be replaced with the installed Bower packages. Since Modernizr is a Bower component, it will be shoved in. Without removing the former Modernizr include from `<head>`, it would be on the page twice.

From [Modernizr Docs](http://modernizr.com/docs/#installing):

> Drop the script tags in the `head` of your HTML. For best performance, you should have them follow after your stylesheet references. The reason we recommend placing Modernizr in the head is two-fold: the HTML5 Shiv (that enables HTML5 elements in IE) must execute before the `<body>`, and if you’re using any of the CSS classes that Modernizr adds, you’ll want to prevent a FOUC.
> 
> If you don't support IE8 and don't need to worry about FOUC, feel free to include modernizr.js whereever.

Let me know if you have any ideas for how we can implement this!
