### PR TITLE
Add prompt for grunt-modernizr

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -19,7 +19,6 @@ var AppGenerator = module.exports = function Appgenerator(args, options, config)
   // resolved to mocha by default (could be switched to jasmine for instance)
   this.hookFor('test-framework', { as: 'app' });
 
-  this.indexFile = this.readFileAsString(path.join(this.sourceRoot(), 'index.html'));
   this.mainCoffeeFile = 'console.log "\'Allo from CoffeeScript!"';
 
   this.on('end', function () {
@@ -50,16 +49,23 @@ AppGenerator.prototype.askFor = function askFor() {
       name: 'RequireJS',
       value: 'includeRequireJS',
       checked: true
+    }, {
+      name: 'Modernizr',
+      value: 'includeModernizr',
+      checked: true
     }]
   }];
 
   this.prompt(prompts, function (answers) {
     var features = answers.features;
 
+    function hasFeature(feat) { return features.indexOf(feat) !== -1; }
+
     // manually deal with the response, get back and store the results.
     // we change a bit this way of doing to automatically do this in the self.prompt() method.
-    this.compassBootstrap = features.indexOf('compassBootstrap') !== -1;
-    this.includeRequireJS = features.indexOf('includeRequireJS') !== -1;
+    this.compassBootstrap = hasFeature('compassBootstrap');
+    this.includeRequireJS = hasFeature('includeRequireJS');
+    this.includeModernizr = hasFeature('includeModernizr');
 
     cb();
   }.bind(this));
@@ -123,6 +129,9 @@ AppGenerator.prototype.writeIndex = function writeIndex() {
     '                <p>You now have</p>',
     '                <ul>'
   ];
+
+  this.indexFile = this.readFileAsString(path.join(this.sourceRoot(), 'index.html'));
+  this.indexFile = this.engine(this.indexFile, this);
 
   if (!this.includeRequireJS) {
     this.indexFile = this.appendScripts(this.indexFile, 'scripts/main.js', [

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -329,7 +329,17 @@ module.exports = function (grunt) {
                 dest: '.tmp/styles/',
                 src: '{,*/}*.css'
             }
-        },
+        },<% if (includeModernizr) { %>
+        modernizr: {
+            devFile: '<%%= yeoman.app %>/bower_components/modernizr/modernizr.js',
+            outputFile: '<%%= yeoman.dist %>/bower_components/modernizr/modernizr.js',
+            files: [
+                '<%%= yeoman.dist %>/scripts/{,*/}*.js',
+                '<%%= yeoman.dist %>/styles/{,*/}*.css',
+                '!<%%= yeoman.dist %>/scripts/vendor/*'
+            ],
+            uglify: true
+        },<% } %>
         concurrent: {
             server: [
                 'compass',
@@ -391,7 +401,8 @@ module.exports = function (grunt) {
         'requirejs',<% } %>
         'concat',
         'cssmin',
-        'uglify',
+        'uglify',<% if (includeModernizr) { %>
+        'modernizr',<% } %>
         'copy:dist',
         'rev',
         'usemin'

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "dependencies": {<% if (compassBootstrap) { %>
     "sass-bootstrap": "~2.3.0",<% } %><% if (includeRequireJS) { %>
-    "requirejs": "~2.1.4",<% } %>
-    "modernizr": "~2.6.2",
+    "requirejs": "~2.1.4",<% } %><% if (includeModernizr) { %>
+    "modernizr": "~2.6.2",<% } %>
     "jquery": "~1.9.1"
   },
   "devDependencies": {}

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -15,7 +15,8 @@
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-htmlmin": "~0.1.3",<% if (includeRequireJS) { %>
     "grunt-bower-requirejs": "~0.4.1",
-    "grunt-contrib-requirejs": "~0.4.0",<% } %>
+    "grunt-contrib-requirejs": "~0.4.0",<% } %><% if (includeModernizr) { %>
+    "grunt-modernizr": "~0.3.0",<% } %>
     "grunt-contrib-imagemin": "~0.1.3",
     "grunt-contrib-watch": "~0.4.0",<% if (testFramework === 'jasmine') { %>
     "grunt-contrib-jasmine": "~0.4.2",<% } %>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,10 +12,10 @@
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
         <!-- build:css(.tmp) styles/main.css -->
         <link rel="stylesheet" href="styles/main.css">
-        <!-- endbuild -->
+        <!-- endbuild --><% if (includeModernizr) { %>
         <!-- build:js scripts/vendor/modernizr.js -->
         <script src="bower_components/modernizr/modernizr.js"></script>
-        <!-- endbuild -->
+        <!-- endbuild --><% } %>
     </head>
     <body>
         <!--[if lt IE 7]>


### PR DESCRIPTION
Fix #107

This adds a prompt for `grunt-modernizr` and removes it completely, if the checkbox is unchecked (#124). I chose to directly overwrite the bower component for Modernizr, which seemed the easiest way. The grunt task is actually really well customizable, so if a detection doesn't work, you can still manually enable or disable certain checks or turn of the autodetection completely.
