### PR TITLE
put Modernizr back in <head>.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -138,11 +138,6 @@ AppGenerator.prototype.writeIndex = function writeIndex() {
   var bowerInstallText
     = '\n        <!-- build:js scripts/vendor.js -->'
     + '\n        <!-- bower:js -->'
-    + (this.includeModernizr
-        ?
-      '\n        <script src="bower_components/modernizr/modernizr.js"></script>'
-        :
-      '')
     + '\n        <script src="bower_components/jquery/jquery.js"></script>'
     + '\n        <!-- endbower -->'
     + '\n        <!-- endbuild -->'

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,7 +12,10 @@
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
         <!-- build:css(.tmp) styles/main.css -->
         <link rel="stylesheet" href="styles/main.css">
-        <!-- endbuild -->
+        <!-- endbuild --><% if (includeModernizr) { %>
+        <!-- build:js scripts/vendor/modernizr.js -->
+        <script src="bower_components/modernizr/modernizr.js"></script>
+        <!-- endbuild --><% } %>
     </head>
     <body>
         <!--[if lt IE 7]>


### PR DESCRIPTION
RE: #123

I changed how [wiredep](https://github.com/stephenplusplus/wiredep), the magic behind grunt-bower-install, works based on @passy's recommendation (:smile_cat:). It will no longer insert a script that's already in the page, outside of the `<!-- bower:js -->..<!-- endbower -->` block. So, that means we can put Modernizr where it belongs, if the user wants it.

Sorry for the last minute change-up!
