### PR TITLE
Making the app source files available in the test directory (fixing #101)

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -77,7 +77,8 @@ module.exports = function (grunt) {
                     middleware: function (connect) {
                         return [
                             mountFolder(connect, '.tmp'),
-                            mountFolder(connect, 'test')
+                            mountFolder(connect, 'test'),
+                            mountFolder(connect, yeomanConfig.app)
                         ];
                     }
                 }


### PR DESCRIPTION
Fixes #101. I have simply copied the solution [from generator-backbone](https://github.com/yeoman/generator-backbone/blob/12ebb0ad89c385c2c3d7a9c6fe5e37e7b2a903a3/app/templates/Gruntfile.js#L102), which is just what @kjarnet suggested.
