### PR TITLE
Fix versions for bower and contrib requirejs

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -14,8 +14,8 @@
     "grunt-contrib-connect": "~0.3.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-htmlmin": "~0.1.3",<% if (includeRequireJS) { %>
-    "grunt-bower-requirejs": "~0.4.1",
-    "grunt-contrib-requirejs": "~0.7.0",<% } else { %>
+    "grunt-bower-requirejs": "~0.7.0",
+    "grunt-contrib-requirejs": "~0.4.1",<% } else { %>
     "grunt-bower-install": "~0.5.0",<% } %>
     "grunt-contrib-imagemin": "~0.2.0",
     "grunt-contrib-watch": "~0.5.2",<% if (testFramework === 'jasmine') { %>


### PR DESCRIPTION
These two versions were flipped. grunt-bower-requirejs is at 0.7.0, while contrib-requirejs is at 0.4.1.
