### PR TITLE
require_main.js: ".js" should not be included in config script paths

### DIFF
--- a/app/templates/require_main.js
+++ b/app/templates/require_main.js
@@ -1,17 +1,17 @@
 require.config({
     paths: {
         jquery: '../bower_components/jquery/jquery'<% if (compassBootstrap) { %>,
-        bootstrapAffix: '../bower_components/sass-bootstrap/js/bootstrap-affix.js',
-        bootstrapAlert: '../bower_components/sass-bootstrap/js/bootstrap-alert.js',
-        bootstrapButton: '../bower_components/sass-bootstrap/js/bootstrap-button.js',
-        bootstrapCarousel: '../bower_components/sass-bootstrap/js/bootstrap-carousel.js',
-        bootstrapCollapse: '../bower_components/sass-bootstrap/js/bootstrap-collapse.js',
-        bootstrapPopover: '../bower_components/sass-bootstrap/js/bootstrap-popover.js',
-        bootstrapScrollspy: '../bower_components/sass-bootstrap/js/bootstrap-scrollspy.js',
-        bootstrapTab: '../bower_components/sass-bootstrap/js/bootstrap-tab.js',
-        bootstrapTooltip: '../bower_components/sass-bootstrap/js/bootstrap-tooltip.js',
-        bootstrapTransition: '../bower_components/sass-bootstrap/js/bootstrap-transition.js',
-        bootstrapTypeahead: '../bower_components/sass-bootstrap/js/bootstrap-typeahead.js'<% } %>
+        bootstrapAffix: '../bower_components/sass-bootstrap/js/bootstrap-affix',
+        bootstrapAlert: '../bower_components/sass-bootstrap/js/bootstrap-alert',
+        bootstrapButton: '../bower_components/sass-bootstrap/js/bootstrap-button',
+        bootstrapCarousel: '../bower_components/sass-bootstrap/js/bootstrap-carousel',
+        bootstrapCollapse: '../bower_components/sass-bootstrap/js/bootstrap-collapse',
+        bootstrapPopover: '../bower_components/sass-bootstrap/js/bootstrap-popover',
+        bootstrapScrollspy: '../bower_components/sass-bootstrap/js/bootstrap-scrollspy',
+        bootstrapTab: '../bower_components/sass-bootstrap/js/bootstrap-tab',
+        bootstrapTooltip: '../bower_components/sass-bootstrap/js/bootstrap-tooltip',
+        bootstrapTransition: '../bower_components/sass-bootstrap/js/bootstrap-transition',
+        bootstrapTypeahead: '../bower_components/sass-bootstrap/js/bootstrap-typeahead'<% } %>
     }<% if (compassBootstrap) { %>,
     shim: {
         bootstrapAffix: {


### PR DESCRIPTION
".js" should not be included in script paths.

Currently, if you try to require one of the bootstrap scripts `require(['app', 'jquery', 'bootstrapTooltip']` an error is thrown

when you try to use it

```
$().tooltip();

// Uncaught TypeError: Object [object Object] has no method 'tooltip'
```

or by requirejs

```
Request URL:http://mewmew.local:9000/bower_components/sass-bootstrap/js/bootstrap-tooltip.js.js

Uncaught Error: Script error for: bootstrapTooltip
http://requirejs.org/docs/errors.html#scripterror 
```
