### PR TITLE
Prevent compass adding cachebuster to assets

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -151,7 +151,8 @@ module.exports = function (grunt) {
                 httpImagesPath: '/images',
                 httpGeneratedImagesPath: '/images/generated',
                 httpFontsPath: '/styles/fonts',
-                relativeAssets: false
+                relativeAssets: false,
+                assetCacheBuster: false
             },
             dist: {
                 options: {


### PR DESCRIPTION
Compass adds a query-string cachebuster to CSS assets, eg `/images/foo.png?12342134123`.

I think we should disable this in webapp, because:
1. it's redundant – we already use revving for cachebusting (in the actual filename)
2. it's not necessarily harmless – the mere presence of a query string can cause some CDNs and proxies to cache less aggressively
