### PR TITLE
Make CoffeeScript optional

### DIFF
--- a/app/USAGE
+++ b/app/USAGE
@@ -6,7 +6,7 @@ Options:
     RequireJS: Add support for AMD-loading via RequireJS
 
 Example:
-    yo webapp
+    yo webapp [--coffee]
 
     This will create:
         Gruntfile.js: Configuration for the task runner.

--- a/app/index.js
+++ b/app/index.js
@@ -10,6 +10,7 @@ var AppGenerator = module.exports = function Appgenerator(args, options, config)
 
   // setup the test-framework property, Gruntfile template will need this
   this.testFramework = options['test-framework'] || 'mocha';
+  this.coffee = options.coffee;
 
   // for hooks to resolve on mocha by default
   if (!options['test-framework']) {
@@ -127,13 +128,15 @@ AppGenerator.prototype.writeIndex = function writeIndex() {
       'scripts/main.js'
     ]);
 
-    this.indexFile = this.appendFiles({
-      html: this.indexFile,
-      fileType: 'js',
-      optimizedPath: 'scripts/coffee.js',
-      sourceFileList: ['scripts/hello.js'],
-      searchPath: '.tmp'
-    });
+    if (this.coffee) {
+      this.indexFile = this.appendFiles({
+        html: this.indexFile,
+        fileType: 'js',
+        optimizedPath: 'scripts/coffee.js',
+        sourceFileList: ['scripts/hello.js'],
+        searchPath: '.tmp'
+      });
+    }
   }
 
   if (this.compassBootstrap && !this.includeRequireJS) {
@@ -183,7 +186,11 @@ AppGenerator.prototype.app = function app() {
   this.mkdir('app/styles');
   this.mkdir('app/images');
   this.write('app/index.html', this.indexFile);
-  this.write('app/scripts/hello.coffee', this.mainCoffeeFile);
+
+  if (this.coffee) {
+    this.write('app/scripts/hello.coffee', this.mainCoffeeFile);
+  }
+
   if (!this.includeRequireJS) {
     this.write('app/scripts/main.js', 'console.log(\'\\\'Allo \\\'Allo!\');');
   }

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -19,7 +19,7 @@ module.exports = function (grunt) {
             app: 'app',
             dist: 'dist'
         },
-        watch: {
+        watch: {<% if (coffee) { %>
             coffee: {
                 files: ['<%%= yeoman.app %>/scripts/{,*/}*.coffee'],
                 tasks: ['coffee:dist']
@@ -27,7 +27,7 @@ module.exports = function (grunt) {
             coffeeTest: {
                 files: ['test/spec/{,*/}*.coffee'],
                 tasks: ['coffee:test']
-            },
+            },<% } %>
             compass: {
                 files: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
                 tasks: ['compass:server', 'autoprefixer']
@@ -118,7 +118,7 @@ module.exports = function (grunt) {
                     specs: 'test/spec/{,*/}*.js'
                 }
             }
-        },<% } %>
+        },<% } %><% if (coffee) { %>
         coffee: {
             dist: {
                 files: [{
@@ -138,7 +138,7 @@ module.exports = function (grunt) {
                     ext: '.js'
                 }]
             }
-        },
+        },<% } %>
         compass: {
             options: {
                 sassDir: '<%%= yeoman.app %>/styles',
@@ -333,16 +333,16 @@ module.exports = function (grunt) {
         },<% } %>
         concurrent: {
             server: [
-                'compass',
-                'coffee:dist',
+                'compass',<% if (coffee) { %>
+                'coffee:dist',<% } %>
                 'copy:styles'
             ],
-            test: [
-                'coffee',
+            test: [<% if (coffee) { %>
+                'coffee',<% } %>
                 'copy:styles'
             ],
-            dist: [
-                'coffee',
+            dist: [<% if (coffee) { %>
+                'coffee',<% } %>
                 'compass',
                 'copy:styles',
                 'imagemin',

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -5,8 +5,8 @@
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-copy": "~0.4.1",
-    "grunt-contrib-concat": "~0.3.0",
-    "grunt-contrib-coffee": "~0.7.0",
+    "grunt-contrib-concat": "~0.3.0",<% if (coffee) { %>
+    "grunt-contrib-coffee": "~0.7.0",<% } %>
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-compass": "~0.5.0",
     "grunt-contrib-jshint": "~0.6.3",

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,9 @@ For more information on what `generator-webapp` can do for you, take a look at t
 
   Defaults to `mocha`. Can be switched for another supported testing framework like `jasmine`.
 
+* `--coffee`
+
+  Add support for [CoffeeScript](http://coffeescript.org/).
 
 ## Contribute
 


### PR DESCRIPTION
Hide CoffeeScript support behind a `--coffee` flag.

Fixes #102

Greetings from the Github HQ!

![photo on 9-24-13 at 8 03 pm 2](https://f.cloud.github.com/assets/9906/1205774/27cd3276-258f-11e3-93e7-aa99e3cdc2d8.jpg)
