### PR TITLE
Make sure Grunt knows to compile Literate CoffeeScript too

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -21,11 +21,11 @@ module.exports = function (grunt) {
         },
         watch: {<% if (coffee) { %>
             coffee: {
-                files: ['<%%= yeoman.app %>/scripts/{,*/}*.coffee'],
+                files: ['<%%= yeoman.app %>/scripts/{,*/}*.{coffee,litcoffee,coffee.md}'],
                 tasks: ['coffee:dist']
             },
             coffeeTest: {
-                files: ['test/spec/{,*/}*.coffee'],
+                files: ['test/spec/{,*/}*.{coffee,litcoffee,coffee.md}'],
                 tasks: ['coffee:test']
             },<% } %>
             compass: {
@@ -125,7 +125,7 @@ module.exports = function (grunt) {
                 files: [{
                     expand: true,
                     cwd: '<%%= yeoman.app %>/scripts',
-                    src: '{,*/}*.coffee',
+                    src: '{,*/}*.{coffee,litcoffee,coffee.md}',
                     dest: '.tmp/scripts',
                     ext: '.js'
                 }]
@@ -134,7 +134,7 @@ module.exports = function (grunt) {
                 files: [{
                     expand: true,
                     cwd: 'test/spec',
-                    src: '{,*/}*.coffee',
+                    src: '{,*/}*.{coffee,litcoffee,coffee.md}',
                     dest: '.tmp/spec',
                     ext: '.js'
                 }]


### PR DESCRIPTION
No idea if this is a legit problem or not, or whether it’s just me missing something obvious, but the default Gruntfile provided by this generator didn’t seem to be picking up any files with `.litcoffee` or `.coffee.md` extensions. It looked to me like the Gruntfile template itself needed updating in order to support this, so this pull requests adds `.litcoffee` and `.coffee.md` extensions to the search paths for CoffeeScript files. Please let me know if there’s a better way to make this work, or if there’s another place I should be submitting this instead :grin:.

Also, the tests for this package seem to only really care about which files the generator places when you run it, so I wasn’t sure if it’d be in-scope to test whether the generated Gruntfile actually compiles the desired extensions or not. Let me know if that’s something that I should try and add in here too (my knowledge of how to test stuff like that in node is pretty much non-existent though… :sweat_smile:).
