### PR TITLE
Use grunt-newer

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -34,7 +34,7 @@ module.exports = function (grunt) {
             },
             styles: {
                 files: ['<%%= yeoman.app %>/styles/{,*/}*.css'],
-                tasks: ['copy:styles', 'autoprefixer']
+                tasks: ['newer:copy:styles', 'autoprefixer']
             },
             livereload: {
                 options: {
@@ -378,7 +378,7 @@ module.exports = function (grunt) {
     ]);
 
     grunt.registerTask('default', [
-        'jshint',
+        'newer:jshint',
         'test',
         'build'
     ]);

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -23,6 +23,7 @@
     "grunt-usemin": "~2.0.0",<% if (testFramework === 'mocha') {  %>
     "grunt-mocha": "~0.4.0",<% } %><% if (includeModernizr) { %>
     "grunt-modernizr": "~0.3.0",<% } %>
+    "grunt-newer": "~0.5.4",
     "grunt-svgmin": "~0.2.0",
     "grunt-concurrent": "~0.3.0",
     "load-grunt-tasks": "~0.1.0",


### PR DESCRIPTION
This brings in the `grunt-newer` task.

There's not really room to speed things up in the `build` task because `clean:dist` is run first (so we always have to process all files again).

Open to other suggestions where this might be put to use.

Closes #151.
