### PR TITLE
Prevent replacing of optimized gifs by copy task

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -290,7 +290,7 @@ module.exports = function (grunt) {
                     src: [
                         '*.{ico,png,txt}',
                         '.htaccess',
-                        'images/{,*/}*.{webp,gif}',
+                        'images/{,*/}*.webp',
                         'styles/fonts/{,*/}*.*'<% if (compassBootstrap) { %>,
                         'bower_components/sass-bootstrap/fonts/*.*'<% } %>
                     ]


### PR DESCRIPTION
1c22955 - gifs added to `imagemin` task, but not removed from `copy` task.
