### PR TITLE
Fix "server" task on readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ For more information on what `generator-webapp` can do for you, take a look at t
 
 - Install: `npm install -g generator-webapp`
 - Run: `yo webapp`
-- Run `grunt` for building and `grunt serve` for preview
+- Run `grunt` for building and `grunt server` for preview
 
 
 ## Options


### PR DESCRIPTION
Task "serve" is not found. Maybe it's "server".

```
➜ git:(master|✔) grunt serve
Warning: Task "serve" not found. Use --force to continue.
```
