### PR TITLE
coffee option fix, dry code, cleaner GF output, JS watch

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -18,8 +18,6 @@ var AppGenerator = module.exports = function Appgenerator(args, options, config)
   // resolved to mocha by default (could be switched to jasmine for instance)
   this.hookFor('test-framework', { as: 'app' });
 
-  this.mainCoffeeFile = 'console.log "\'Allo from CoffeeScript!"';
-
   this.on('end', function () {
     this.installDependencies({
       skipInstall: options['skip-install'],
@@ -104,14 +102,12 @@ AppGenerator.prototype.h5bp = function h5bp() {
 };
 
 AppGenerator.prototype.mainStylesheet = function mainStylesheet() {
-  if (this.compassBootstrap) {
-    this.copy('main.scss', 'app/styles/main.scss');
-  } else {
-    this.copy('main.css', 'app/styles/main.css');
-  }
+  var css = 'main.' + (this.compassBootstrap ? 's' : '') + 'css';
+  this.copy(css, 'app/styles/' + css);
 };
 
 AppGenerator.prototype.writeIndex = function writeIndex() {
+  var bs;
 
   this.indexFile = this.readFileAsString(path.join(this.sourceRoot(), 'index.html'));
   this.indexFile = this.engine(this.indexFile, this);
@@ -119,31 +115,22 @@ AppGenerator.prototype.writeIndex = function writeIndex() {
     'scripts/main.js'
   ]);
 
-  if (this.coffee) {
-    this.indexFile = this.appendFiles({
-      html: this.indexFile,
-      fileType: 'js',
-      optimizedPath: 'scripts/coffee.js',
-      sourceFileList: ['scripts/hello.js'],
-      searchPath: '.tmp'
-    });
-  }
-
   if (this.compassBootstrap) {
     // wire Twitter Bootstrap plugins
+    bs = 'bower_components/sass-bootstrap/js/';
     this.indexFile = this.appendScripts(this.indexFile, 'scripts/plugins.js', [
-      'bower_components/sass-bootstrap/js/affix.js',
-      'bower_components/sass-bootstrap/js/alert.js',
-      'bower_components/sass-bootstrap/js/dropdown.js',
-      'bower_components/sass-bootstrap/js/tooltip.js',
-      'bower_components/sass-bootstrap/js/modal.js',
-      'bower_components/sass-bootstrap/js/transition.js',
-      'bower_components/sass-bootstrap/js/button.js',
-      'bower_components/sass-bootstrap/js/popover.js',
-      'bower_components/sass-bootstrap/js/carousel.js',
-      'bower_components/sass-bootstrap/js/scrollspy.js',
-      'bower_components/sass-bootstrap/js/collapse.js',
-      'bower_components/sass-bootstrap/js/tab.js'
+      bs + 'affix.js',
+      bs + 'alert.js',
+      bs + 'dropdown.js',
+      bs + 'tooltip.js',
+      bs + 'modal.js',
+      bs + 'transition.js',
+      bs + 'button.js',
+      bs + 'popover.js',
+      bs + 'carousel.js',
+      bs + 'scrollspy.js',
+      bs + 'collapse.js',
+      bs + 'tab.js'
     ]);
   }
 };
@@ -156,8 +143,12 @@ AppGenerator.prototype.app = function app() {
   this.write('app/index.html', this.indexFile);
 
   if (this.coffee) {
-    this.write('app/scripts/hello.coffee', this.mainCoffeeFile);
+    this.write(
+      'app/scripts/main.coffee',
+      'console.log "\'Allo from CoffeeScript!"'
+    );
   }
-
-  this.write('app/scripts/main.js', 'console.log(\'\\\'Allo \\\'Allo!\');');
+  else {
+    this.write('app/scripts/main.js', 'console.log(\'\\\'Allo \\\'Allo!\');');
+  }
 };

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -35,6 +35,13 @@ module.exports = function (grunt) {
                 files: ['test/spec/{,*/}*.{coffee,litcoffee,coffee.md}'],
                 tasks: ['coffee:test', 'test:watch']
             },<% } else { %>
+            js: {
+                files: ['<%%= yeoman.app %>/scripts/{,*/}*.js'],
+                tasks: ['jshint'],
+                options: {
+                    livereload: true
+                }
+            },
             jstest: {
                 files: ['test/spec/{,*/}*.js'],
                 tasks: ['test:watch']
@@ -56,8 +63,8 @@ module.exports = function (grunt) {
                 },
                 files: [
                     '<%%= yeoman.app %>/*.html',
-                    '.tmp/styles/{,*/}*.css',
-                    '{.tmp,<%%= yeoman.app %>}/scripts/{,*/}*.js',
+                    '.tmp/styles/{,*/}*.css',<% if (coffee) { %>
+                    '.tmp/scripts/{,*/}*.js',<% } %>
                     '<%%= yeoman.app %>/images/{,*/}*.{gif,jpeg,jpg,png,svg,webp}'
                 ]
             }
@@ -128,7 +135,7 @@ module.exports = function (grunt) {
             ]
         },
 
-        <% if (testFramework === 'mocha') { %>
+<% if (testFramework === 'mocha') { %>
         // Mocha testing framework configuration options
         mocha: {
             all: {
@@ -147,7 +154,7 @@ module.exports = function (grunt) {
             }
         },<% } %>
 
-        <% if (coffee) { %>
+<% if (coffee) { %>
         // Compiles CoffeeScript to JavaScript
         coffee: {
             dist: {
@@ -348,7 +355,7 @@ module.exports = function (grunt) {
             }
         },
 
-        <% if (includeModernizr) { %>
+<% if (includeModernizr) { %>
         // Generates a custom Modernizr build that includes only the tests you
         // reference in your app
         modernizr: {

--- a/test/test.js
+++ b/test/test.js
@@ -36,8 +36,7 @@ describe('Webapp generator test', function () {
       'app/favicon.ico',
       'app/robots.txt',
       'app/index.html',
-      'app/scripts/hello.coffee',
-      'app/scripts/main.js',
+      'app/scripts/main.coffee',
       'app/styles/main.scss'
     ];
 


### PR DESCRIPTION
- Don't create JS files when --coffee is chosen
- JSHint and livereload JS in serve mode
- DRY up index.js a bit
- Get rid of trailing whitespace in generated Gruntfile.js

Fixes #200
BREAKING CHANGE: When choosing --coffee, JS files will no longer be
created automatically as well.
