### PR TITLE
Fix #190: modernizr task

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -434,9 +434,9 @@ module.exports = function (grunt) {
         'autoprefixer',
         'concat',
         'cssmin',
-        'uglify',<% if (includeModernizr) { %>
+        'uglify',
+        'copy:dist',<% if (includeModernizr) { %>
         'modernizr',<% } %>
-        'copy:dist',
         'rev',
         'usemin'
     ]);

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -13,9 +13,8 @@
         <!-- build:css(.tmp) styles/main.css -->
         <link rel="stylesheet" href="styles/main.css">
         <!-- endbuild --><% if (includeModernizr) { %>
-        <!-- build:js scripts/vendor/modernizr.js -->
         <script src="bower_components/modernizr/modernizr.js"></script>
-        <!-- endbuild --><% } %>
+        <% } %>
     </head>
     <body>
         <!--[if lt IE 10]>


### PR DESCRIPTION
The Modernizr inclusion should happen outside of a usemin block, since the task
itself takes care of uglification and should not be replaced by the full build.
