### PR TITLE
Specify where bower should look for bower.json

### DIFF
--- a/app/templates/bowerrc
+++ b/app/templates/bowerrc
@@ -1,3 +1,4 @@
 {
-    "directory": "app/bower_components"
+    "directory": "app/bower_components",
+    "json": "bower.json"
 }


### PR DESCRIPTION
Fix for #96
Now Bower will know where to look for bower.json and the installation will work out of the box for Windows machines. 
