### PR TITLE
Use `grunt-bower-install` for CSS dependencies.

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -10,6 +10,10 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+        <!-- build:css styles/vendor.css -->
+        <!-- bower:css -->
+        <!-- endbower -->
+        <!-- endbuild -->
         <!-- build:css(.tmp) styles/main.css -->
         <link rel="stylesheet" href="styles/main.css">
         <!-- endbuild --><% if (includeModernizr) { %>


### PR DESCRIPTION
@gojohnnygo made a good point in https://github.com/stephenplusplus/grunt-bower-install/issues/25#issuecomment-30177128 ... the webapp generator ships with JS support for `grunt-bower-install`, but gbi now also handles CSS deps as well.

Thought I'd get a few opinions on this before brute merging it in.

One thought I had was only using gbi for CSS if the user didn't opt into compass. Would that make sense, or not really?
