### PR TITLE
Remove version, add private to bower.json template

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -1,6 +1,6 @@
 {
   "name": "<%= _.slugify(appname) %>",
-  "version": "0.0.0",
+  "private": true,
   "dependencies": {<% if (compassBootstrap) { %>
     "sass-bootstrap": "~3.0.0",<% } %><% if (includeModernizr) { %>
     "modernizr": "~2.6.2",<% } %>


### PR DESCRIPTION
Set the private property in bower.json template and remove the optional version property, as you wouldn't normally want to publish a webapp to the bower package registry.
