### PR TITLE
Refactoring CSS Pre-Processing

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -48,8 +48,12 @@ AppGenerator.prototype.askFor = function askFor() {
     name: 'features',
     message: 'What more would you like?',
     choices: [{
-      name: 'Bootstrap for Sass',
-      value: 'compassBootstrap',
+      name: 'Sass with Compass',
+      value: 'includeCompass',
+      checked: true
+    }, {
+      name: 'Bootstrap',
+      value: 'includeBootstrap',
       checked: true
     }, {
       name: 'Modernizr',
@@ -65,7 +69,8 @@ AppGenerator.prototype.askFor = function askFor() {
 
     // manually deal with the response, get back and store the results.
     // we change a bit this way of doing to automatically do this in the self.prompt() method.
-    this.compassBootstrap = hasFeature('compassBootstrap');
+    this.includeCompass = hasFeature('includeCompass');
+    this.includeBootstrap = hasFeature('includeBootstrap');
     this.includeModernizr = hasFeature('includeModernizr');
 
     cb();
@@ -106,19 +111,18 @@ AppGenerator.prototype.h5bp = function h5bp() {
 };
 
 AppGenerator.prototype.mainStylesheet = function mainStylesheet() {
-  var css = 'main.' + (this.compassBootstrap ? 's' : '') + 'css';
+  var css = 'main.' + (this.includeCompass ? 's' : '') + 'css';
   this.copy(css, 'app/styles/' + css);
 };
 
 AppGenerator.prototype.writeIndex = function writeIndex() {
-  var bs;
 
   this.indexFile = this.readFileAsString(path.join(this.sourceRoot(), 'index.html'));
   this.indexFile = this.engine(this.indexFile, this);
 
-  if (this.compassBootstrap) {
-    // wire Twitter Bootstrap plugins
-    bs = 'bower_components/sass-bootstrap/js/';
+  // wire Twitter Bootstrap plugins
+  if (this.includeBootstrap) {
+    var bs = 'bower_components/' + (this.includeCompass ? 'sass-' : '') + 'bootstrap/js/';
     this.indexFile = this.appendScripts(this.indexFile, 'scripts/plugins.js', [
       bs + 'affix.js',
       bs + 'alert.js',

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -48,11 +48,11 @@ module.exports = function (grunt) {
             },<% } %>
             gruntfile: {
                 files: ['Gruntfile.js']
-            },
+            },<% if (compassBootstrap) { %>
             compass: {
                 files: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
                 tasks: ['compass:server', 'autoprefixer']
-            },
+            },<% } %>
             styles: {
                 files: ['<%%= yeoman.app %>/styles/{,*/}*.css'],
                 tasks: ['newer:copy:styles', 'autoprefixer']
@@ -177,6 +177,7 @@ module.exports = function (grunt) {
             }
         },<% } %>
 
+<% if (compassBootstrap) { %>
         // Compiles Sass to CSS and generates necessary files if requested
         compass: {
             options: {
@@ -203,7 +204,7 @@ module.exports = function (grunt) {
                     debugInfo: true
                 }
             }
-        },
+        },<% } %>
 
         // Add vendor prefixed styles
         autoprefixer: {
@@ -372,8 +373,8 @@ module.exports = function (grunt) {
 
         // Run some tasks in parallel to speed up build process
         concurrent: {
-            server: [
-                'compass:server',<% if (coffee) { %>
+            server: [<% if (compassBootstrap) { %>
+                'compass:server',<% } if (coffee) { %>
                 'coffee:dist',<% } %>
                 'copy:styles'
             ],
@@ -382,8 +383,8 @@ module.exports = function (grunt) {
                 'copy:styles'
             ],
             dist: [<% if (coffee) { %>
-                'coffee',<% } %>
-                'compass',
+                'coffee',<% } if (compassBootstrap) { %>
+                'compass',<% } %>
                 'copy:styles',
                 'imagemin',
                 'svgmin'

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -48,7 +48,7 @@ module.exports = function (grunt) {
             },<% } %>
             gruntfile: {
                 files: ['Gruntfile.js']
-            },<% if (compassBootstrap) { %>
+            },<% if (includeCompass) { %>
             compass: {
                 files: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
                 tasks: ['compass:server', 'autoprefixer']
@@ -177,7 +177,7 @@ module.exports = function (grunt) {
             }
         },<% } %>
 
-<% if (compassBootstrap) { %>
+<% if (includeCompass) { %>
         // Compiles Sass to CSS and generates necessary files if requested
         compass: {
             options: {
@@ -343,8 +343,8 @@ module.exports = function (grunt) {
                         '.htaccess',
                         'images/{,*/}*.webp',
                         '{,*/}*.html',
-                        'styles/fonts/{,*/}*.*'<% if (compassBootstrap) { %>,
-                        'bower_components/sass-bootstrap/fonts/*.*'<% } %>
+                        'styles/fonts/{,*/}*.*'<% if (includeBootstrap) { %>,
+                        'bower_components/' + (this.includeCompass ? 'sass-' : '') + 'bootstrap/' + (this.includeCompass ? 'fonts/' : 'dist/fonts/') +'*.*'<% } %>
                     ]
                 }]
             },
@@ -373,7 +373,7 @@ module.exports = function (grunt) {
 
         // Run some tasks in parallel to speed up build process
         concurrent: {
-            server: [<% if (compassBootstrap) { %>
+            server: [<% if (includeCompass) { %>
                 'compass:server',<% } if (coffee) { %>
                 'coffee:dist',<% } %>
                 'copy:styles'
@@ -383,7 +383,7 @@ module.exports = function (grunt) {
                 'copy:styles'
             ],
             dist: [<% if (coffee) { %>
-                'coffee',<% } if (compassBootstrap) { %>
+                'coffee',<% } if (includeCompass) { %>
                 'compass',<% } %>
                 'copy:styles',
                 'imagemin',

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -1,8 +1,9 @@
 {
   "name": "<%= _.slugify(appname) %>",
   "private": true,
-  "dependencies": {<% if (compassBootstrap) { %>
-    "sass-bootstrap": "~3.0.0",<% } %><% if (includeModernizr) { %>
+  "dependencies": {<% if (includeBootstrap) { if (includeCompass) { %>
+    "sass-bootstrap": "~3.0.0",<% } else { %>
+    "bootstrap": "~3.0.3",<% }} if (includeModernizr) { %>
     "modernizr": "~2.6.2",<% } %>
     "jquery": "~1.10.2"
   },

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -7,8 +7,8 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-concat": "~0.3.0",<% if (coffee) { %>
     "grunt-contrib-coffee": "~0.7.0",<% } %>
-    "grunt-contrib-uglify": "~0.2.0",
-    "grunt-contrib-compass": "~0.7.0",
+    "grunt-contrib-uglify": "~0.2.0",<% if (compassBootstrap) { %>
+    "grunt-contrib-compass": "~0.7.0",<% } %>
     "grunt-contrib-jshint": "~0.7.0",
     "grunt-contrib-cssmin": "~0.7.0",
     "grunt-contrib-connect": "~0.5.0",

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -7,7 +7,7 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-concat": "~0.3.0",<% if (coffee) { %>
     "grunt-contrib-coffee": "~0.7.0",<% } %>
-    "grunt-contrib-uglify": "~0.2.0",<% if (compassBootstrap) { %>
+    "grunt-contrib-uglify": "~0.2.0",<% if (includeCompass) { %>
     "grunt-contrib-compass": "~0.7.0",<% } %>
     "grunt-contrib-jshint": "~0.7.0",
     "grunt-contrib-cssmin": "~0.7.0",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,6 +12,7 @@
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
         <!-- build:css styles/vendor.css -->
         <!-- bower:css -->
+        <% if (includeBootstrap && !includeCompass) { %><link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.min.css"><% } %>
         <!-- endbower -->
         <!-- endbuild -->
         <!-- build:css(.tmp) styles/main.css -->
@@ -25,7 +26,7 @@
             <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
         <![endif]-->
 
-        <% if (compassBootstrap) { %>
+        <% if (includeBootstrap) { %>
         <div class="container">
             <div class="header">
                 <ul class="nav nav-pills pull-right">
@@ -47,6 +48,10 @@
                     <h4>HTML5 Boilerplate</h4>
                     <p>HTML5 Boilerplate is a professional front-end template for building fast, robust, and adaptable web apps or sites.</p>
 
+                    <% if (includeCompass) { %><h4>Sass with Compass</h4>
+                    <p>Compass is an open-source CSS Authoring Framework that uses Sass.</p>
+                    <% } %>
+
                     <h4>Bootstrap</h4>
                     <p>Sleek, intuitive, and powerful mobile first front-end framework for faster and easier web development.</p>
 
@@ -61,16 +66,17 @@
             </div>
 
         </div>
-        <% } else { // compassBootstrap %>
+        <% } else { %>
         <div class="hero-unit">
           <h1>'Allo, 'Allo!</h1>
           <p>You now have</p>
           <ul>
             <li>HTML5 Boilerplate</li>
+            <% if (includeCompass) { %><li>Sass with Compass</li><% } %>
             <% if (includeModernizr) { %><li>Modernizr</li><% } %>
           </ul>
         </div>
-        <% } // compassBootstrap %>
+        <% } %>
 
         <!-- build:js scripts/vendor.js -->
         <!-- bower:js -->

--- a/app/templates/main.css
+++ b/app/templates/main.css
@@ -1,4 +1,92 @@
+<% if (includeBootstrap) { %>.browsehappy {
+    margin: 0.2em 0;
+    background: #ccc;
+    color: #000;
+    padding: 0.2em 0;
+}
+
+/* Space out content a bit */
 body {
+    padding-top: 20px;
+    padding-bottom: 20px;
+}
+
+/* Everything but the jumbotron gets side spacing for mobile first views */
+.header,
+.marketing,
+.footer {
+    padding-left: 15px;
+    padding-right: 15px;
+}
+
+/* Custom page header */
+.header {
+    border-bottom: 1px solid #e5e5e5;
+}
+
+/* Make the masthead heading the same height as the navigation */
+.header h3 {
+    margin-top: 0;
+    margin-bottom: 0;
+    line-height: 40px;
+    padding-bottom: 19px;
+}
+
+/* Custom page footer */
+.footer {
+    padding-top: 19px;
+    color: #777;
+    border-top: 1px solid #e5e5e5;
+}
+
+.container-narrow > hr {
+    margin: 30px 0;
+}
+
+/* Main marketing message and sign up button */
+.jumbotron {
+    text-align: center;
+    border-bottom: 1px solid #e5e5e5;
+}
+
+.jumbotron .btn {
+    font-size: 21px;
+    padding: 14px 24px;
+}
+
+/* Supporting marketing content */
+.marketing {
+    margin: 40px 0;
+}
+
+.marketing p + h4 {
+    margin-top: 28px;
+}
+
+/* Responsive: Portrait tablets and up */
+@media screen and (min-width: 768px) {
+    .container {
+        max-width: 730px;
+    }
+
+    /* Remove the padding we set earlier */
+    .header,
+    .marketing,
+    .footer {
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    /* Space out the masthead */
+    .header {
+        margin-bottom: 30px;
+    }
+    
+    /* Remove the bottom border on the jumbotron for visual effect */
+    .jumbotron {
+        border-bottom: 0;
+    }
+}<% } else { %>body {
     background: #fafafa;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     color: #333;
@@ -26,4 +114,4 @@ body {
     background: #ccc;
     color: #000;
     padding: 0.2em 0;
-}
+}<% } %>

--- a/app/templates/main.scss
+++ b/app/templates/main.scss
@@ -1,4 +1,4 @@
-$icon-font-path: "/bower_components/sass-bootstrap/fonts/";
+<% if (includeBootstrap) { %>$icon-font-path: "/bower_components/sass-bootstrap/fonts/";
 
 @import 'sass-bootstrap/lib/bootstrap';
 
@@ -26,14 +26,14 @@ body {
 /* Custom page header */
 .header {
     border-bottom: 1px solid #e5e5e5;
-}
 
-/* Make the masthead heading the same height as the navigation */
-.header h3 {
-    margin-top: 0;
-    margin-bottom: 0;
-    line-height: 40px;
-    padding-bottom: 19px;
+    /* Make the masthead heading the same height as the navigation */
+    h3 {
+        margin-top: 0;
+        margin-bottom: 0;
+        line-height: 40px;
+        padding-bottom: 19px;
+    }
 }
 
 /* Custom page footer */
@@ -51,20 +51,18 @@ body {
 .jumbotron {
     text-align: center;
     border-bottom: 1px solid #e5e5e5;
-}
-
-.jumbotron .btn {
-    font-size: 21px;
-    padding: 14px 24px;
+    .btn {
+        font-size: 21px;
+        padding: 14px 24px;
+    }
 }
 
 /* Supporting marketing content */
 .marketing {
     margin: 40px 0;
-}
-
-.marketing p + h4 {
-    margin-top: 28px;
+    p + h4 {
+        margin-top: 28px;
+    }
 }
 
 /* Responsive: Portrait tablets and up */
@@ -80,12 +78,41 @@ body {
         padding-left: 0;
         padding-right: 0;
     }
+
     /* Space out the masthead */
     .header {
         margin-bottom: 30px;
     }
+    
     /* Remove the bottom border on the jumbotron for visual effect */
     .jumbotron {
         border-bottom: 0;
     }
+}<% } else { %>body {
+    background: #fafafa;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    color: #333;
 }
+
+.hero-unit {
+    margin: 50px auto 0 auto;
+    width: 300px;
+    font-size: 18px;
+    font-weight: 200;
+    line-height: 30px;
+    background-color: #eee;
+    border-radius: 6px;
+    padding: 60px;
+    h1 {
+        font-size: 60px;
+        line-height: 1;
+        letter-spacing: -1px;
+    }
+}
+
+.browsehappy {
+    margin: 0.2em 0;
+    background: #ccc;
+    color: #000;
+    padding: 0.2em 0;
+}<% } %>

--- a/test/test.js
+++ b/test/test.js
@@ -41,7 +41,7 @@ describe('Webapp generator test', function () {
     ];
 
     helpers.mockPrompt(this.webapp, {
-      features: ['compassBootstrap']
+      features: ['includeCompass']
     });
 
     this.webapp.coffee = true;
@@ -66,7 +66,7 @@ describe('Webapp generator test', function () {
     ];
 
     helpers.mockPrompt(this.webapp, {
-      features: ['compassBootstrap']
+      features: ['includeCompass']
     });
 
     this.webapp.coffee = false;
@@ -91,7 +91,7 @@ describe('Webapp generator test', function () {
     ];
 
     helpers.mockPrompt(this.webapp, {
-      features: ['compassBootstrap']
+      features: ['includeCompass']
     });
 
     this.webapp.options['skip-install'] = true;


### PR DESCRIPTION
Pull request for [this issue](https://github.com/yeoman/generator-webapp/issues/237) consists of 2 major changes:

1) Binding Compass functions to the compassBootstrap (now includeCompass) variable. As mentioned in my issue, there was another relatively popular issue on [making the Compass grunt task optional](https://github.com/yeoman/generator-webapp/issues/114). Compass functions are now only included if the user selects to use Sass pre-processing.

2) Separate Bootstrap from Sass with Compass. This was a major change discussed between @addyosmani, @sindresorhus and myself. Rather than the previous `Bootstrap with Sass` option, the prompt is now:

```
[] Sass with Compass
[] Bootstrap
[] Modernizr
```

which results in the following 4 workflows:
- Just CSS
- Just Sass
- Bootstrap with CSS
- Bootstrap with Sass

Each workflow has been tested with `grunt` and `grunt serve` functions.
