### PR TITLE
separates task configs to files

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -79,6 +79,35 @@ AppGenerator.prototype.askFor = function askFor() {
 
 AppGenerator.prototype.gruntfile = function gruntfile() {
   this.template('Gruntfile.js');
+  this.template('grunt/autoprefixer.js');
+  this.template('grunt/bower-install.js');
+  this.template('grunt/clean.js');
+  this.template('grunt/concurrent.js');
+  this.template('grunt/connect.js');
+  this.template('grunt/copy.js');
+  this.template('grunt/htmlmin.js');
+  this.template('grunt/imagemin.js');
+  this.template('grunt/jshint.js');
+  this.template('grunt/rev.js');
+  this.template('grunt/svgmin.js');
+  this.template('grunt/usemin.js');
+  this.template('grunt/useminPrepare.js');
+  this.template('grunt/watch.js');
+  
+  if (this.testFramework === 'mocha'){
+    this.template('grunt/mocha.js');
+  }else if(this.testFramework === 'jasmine'){
+    this.template('grunt/jasmine.js');
+  }
+  if(this.coffee){
+    this.template('grunt/coffee.js');
+  }
+  if(this.includeCompass){
+    this.template('grunt/compass.js');
+  }
+  if(this.includeModernizr){
+    this.template('grunt/modernizr.js');
+  }
 };
 
 AppGenerator.prototype.packageJSON = function packageJSON() {

--- a/app/index.js
+++ b/app/index.js
@@ -30,6 +30,7 @@ var AppGenerator = module.exports = function Appgenerator(args, options, config)
   this.options = options;
 
   this.pkg = JSON.parse(this.readFileAsString(path.join(__dirname, '../package.json')));
+  this.gruntpath = JSON.parse(this.readFileAsString(path.join(this.sourceRoot(), 'gruntrc'))).directory;
 };
 
 util.inherits(AppGenerator, yeoman.generators.Base);
@@ -78,35 +79,36 @@ AppGenerator.prototype.askFor = function askFor() {
 };
 
 AppGenerator.prototype.gruntfile = function gruntfile() {
+  this.copy('gruntrc', '.gruntrc');
   this.template('Gruntfile.js');
-  this.template('grunt/autoprefixer.js');
-  this.template('grunt/bower-install.js');
-  this.template('grunt/clean.js');
-  this.template('grunt/concurrent.js');
-  this.template('grunt/connect.js');
-  this.template('grunt/copy.js');
-  this.template('grunt/htmlmin.js');
-  this.template('grunt/imagemin.js');
-  this.template('grunt/jshint.js');
-  this.template('grunt/rev.js');
-  this.template('grunt/svgmin.js');
-  this.template('grunt/usemin.js');
-  this.template('grunt/useminPrepare.js');
-  this.template('grunt/watch.js');
-  
+  this.template(this.gruntpath+'/autoprefixer.js');
+  this.template(this.gruntpath+'/bower-install.js');
+  this.template(this.gruntpath+'/clean.js');
+  this.template(this.gruntpath+'/concurrent.js');
+  this.template(this.gruntpath+'/connect.js');
+  this.template(this.gruntpath+'/copy.js');
+  this.template(this.gruntpath+'/htmlmin.js');
+  this.template(this.gruntpath+'/imagemin.js');
+  this.template(this.gruntpath+'/jshint.js');
+  this.template(this.gruntpath+'/rev.js');
+  this.template(this.gruntpath+'/svgmin.js');
+  this.template(this.gruntpath+'/usemin.js');
+  this.template(this.gruntpath+'/useminPrepare.js');
+  this.template(this.gruntpath+'/watch.js');
+
   if (this.testFramework === 'mocha'){
-    this.template('grunt/mocha.js');
+    this.template(this.gruntpath+'/mocha.js');
   }else if(this.testFramework === 'jasmine'){
-    this.template('grunt/jasmine.js');
+    this.template(this.gruntpath+'/jasmine.js');
   }
   if(this.coffee){
-    this.template('grunt/coffee.js');
+    this.template(this.gruntpath+'/coffee.js');
   }
   if(this.includeCompass){
-    this.template('grunt/compass.js');
+    this.template(this.gruntpath+'/compass.js');
   }
   if(this.includeModernizr){
-    this.template('grunt/modernizr.js');
+    this.template(this.gruntpath+'/modernizr.js');
   }
 };
 

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -39,8 +39,10 @@ module.exports = function (grunt) {
         }
     }
 
+	var configsPath = grunt.file.readJSON('.gruntrc').directory;
+
     // Define the configuration for all the tasks
-    grunt.util._.extend(config, loadConfig('./grunt/'));
+    grunt.util._.extend(config, loadConfig(configsPath));
 
     grunt.initConfig(config);
 

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -7,6 +7,21 @@
 // use this if you want to recursively match all subfolders:
 // 'test/spec/**/*.js'
 
+
+//based on https://gist.github.com/thomasboyt/6406507#file-load_config-js
+function loadConfig(path){
+    var glob = require('glob');
+    var object = {};
+    var key;
+
+    glob.sync('*', {cwd : path}).forEach(function(option){
+        key = option.replace(/\.js$/, '');
+        object[key] = require(path + option);
+    });
+
+    return object;
+}
+
 module.exports = function (grunt) {
 
     // Load grunt tasks automatically
@@ -15,382 +30,19 @@ module.exports = function (grunt) {
     // Time how long tasks take. Can help when optimizing build times
     require('time-grunt')(grunt);
 
-    // Define the configuration for all the tasks
-    grunt.initConfig({
-
+    var config = {
         // Project settings
         yeoman: {
             // Configurable paths
             app: 'app',
             dist: 'dist'
-        },
-
-        // Watches files for changes and runs tasks based on the changed files
-        watch: {<% if (coffee) { %>
-            coffee: {
-                files: ['<%%= yeoman.app %>/scripts/{,*/}*.{coffee,litcoffee,coffee.md}'],
-                tasks: ['coffee:dist']
-            },
-            coffeeTest: {
-                files: ['test/spec/{,*/}*.{coffee,litcoffee,coffee.md}'],
-                tasks: ['coffee:test', 'test:watch']
-            },<% } else { %>
-            js: {
-                files: ['<%%= yeoman.app %>/scripts/{,*/}*.js'],
-                tasks: ['jshint'],
-                options: {
-                    livereload: true
-                }
-            },
-            jstest: {
-                files: ['test/spec/{,*/}*.js'],
-                tasks: ['test:watch']
-            },<% } %>
-            gruntfile: {
-                files: ['Gruntfile.js']
-            },<% if (includeCompass) { %>
-            compass: {
-                files: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
-                tasks: ['compass:server', 'autoprefixer']
-            },<% } %>
-            styles: {
-                files: ['<%%= yeoman.app %>/styles/{,*/}*.css'],
-                tasks: ['newer:copy:styles', 'autoprefixer']
-            },
-            livereload: {
-                options: {
-                    livereload: '<%%= connect.options.livereload %>'
-                },
-                files: [
-                    '<%%= yeoman.app %>/{,*/}*.html',
-                    '.tmp/styles/{,*/}*.css',<% if (coffee) { %>
-                    '.tmp/scripts/{,*/}*.js',<% } %>
-                    '<%%= yeoman.app %>/images/{,*/}*.{gif,jpeg,jpg,png,svg,webp}'
-                ]
-            }
-        },
-
-        // The actual grunt server settings
-        connect: {
-            options: {
-                port: 9000,
-                livereload: 35729,
-                // Change this to '0.0.0.0' to access the server from outside
-                hostname: 'localhost'
-            },
-            livereload: {
-                options: {
-                    open: true,
-                    base: [
-                        '.tmp',
-                        '<%%= yeoman.app %>'
-                    ]
-                }
-            },
-            test: {
-                options: {
-                    port: 9001,
-                    base: [
-                        '.tmp',
-                        'test',
-                        '<%%= yeoman.app %>'
-                    ]
-                }
-            },
-            dist: {
-                options: {
-                    open: true,
-                    base: '<%%= yeoman.dist %>',
-                    livereload: false
-                }
-            }
-        },
-
-        // Empties folders to start fresh
-        clean: {
-            dist: {
-                files: [{
-                    dot: true,
-                    src: [
-                        '.tmp',
-                        '<%%= yeoman.dist %>/*',
-                        '!<%%= yeoman.dist %>/.git*'
-                    ]
-                }]
-            },
-            server: '.tmp'
-        },
-
-        // Make sure code styles are up to par and there are no obvious mistakes
-        jshint: {
-            options: {
-                jshintrc: '.jshintrc',
-                reporter: require('jshint-stylish')
-            },
-            all: [
-                'Gruntfile.js',
-                '<%%= yeoman.app %>/scripts/{,*/}*.js',
-                '!<%%= yeoman.app %>/scripts/vendor/*',
-                'test/spec/{,*/}*.js'
-            ]
-        },
-
-<% if (testFramework === 'mocha') { %>
-        // Mocha testing framework configuration options
-        mocha: {
-            all: {
-                options: {
-                    run: true,
-                    urls: ['http://<%%= connect.test.options.hostname %>:<%%= connect.test.options.port %>/index.html']
-                }
-            }
-        },<% } else if (testFramework === 'jasmine') { %>
-        // Jasmine testing framework configuration options
-        jasmine: {
-            all: {
-                options: {
-                    specs: 'test/spec/{,*/}*.js'
-                }
-            }
-        },<% } %>
-
-<% if (coffee) { %>
-        // Compiles CoffeeScript to JavaScript
-        coffee: {
-            dist: {
-                files: [{
-                    expand: true,
-                    cwd: '<%%= yeoman.app %>/scripts',
-                    src: '{,*/}*.{coffee,litcoffee,coffee.md}',
-                    dest: '.tmp/scripts',
-                    ext: '.js'
-                }]
-            },
-            test: {
-                files: [{
-                    expand: true,
-                    cwd: 'test/spec',
-                    src: '{,*/}*.{coffee,litcoffee,coffee.md}',
-                    dest: '.tmp/spec',
-                    ext: '.js'
-                }]
-            }
-        },<% } %>
-
-<% if (includeCompass) { %>
-        // Compiles Sass to CSS and generates necessary files if requested
-        compass: {
-            options: {
-                sassDir: '<%%= yeoman.app %>/styles',
-                cssDir: '.tmp/styles',
-                generatedImagesDir: '.tmp/images/generated',
-                imagesDir: '<%%= yeoman.app %>/images',
-                javascriptsDir: '<%%= yeoman.app %>/scripts',
-                fontsDir: '<%%= yeoman.app %>/styles/fonts',
-                importPath: '<%%= yeoman.app %>/bower_components',
-                httpImagesPath: '/images',
-                httpGeneratedImagesPath: '/images/generated',
-                httpFontsPath: '/styles/fonts',
-                relativeAssets: false,
-                assetCacheBuster: false
-            },
-            dist: {
-                options: {
-                    generatedImagesDir: '<%%= yeoman.dist %>/images/generated'
-                }
-            },
-            server: {
-                options: {
-                    debugInfo: true
-                }
-            }
-        },<% } %>
-
-        // Add vendor prefixed styles
-        autoprefixer: {
-            options: {
-                browsers: ['last 1 version']
-            },
-            dist: {
-                files: [{
-                    expand: true,
-                    cwd: '.tmp/styles/',
-                    src: '{,*/}*.css',
-                    dest: '.tmp/styles/'
-                }]
-            }
-        },
-
-        // Automatically inject Bower components into the HTML file
-        'bower-install': {
-            app: {
-                html: '<%%= yeoman.app %>/index.html',
-                ignorePath: '<%%= yeoman.app %>/'
-            }
-        },
-
-        // Renames files for browser caching purposes
-        rev: {
-            dist: {
-                files: {
-                    src: [
-                        '<%%= yeoman.dist %>/scripts/{,*/}*.js',
-                        '<%%= yeoman.dist %>/styles/{,*/}*.css',
-                        '<%%= yeoman.dist %>/images/{,*/}*.{gif,jpeg,jpg,png,webp}',
-                        '<%%= yeoman.dist %>/styles/fonts/{,*/}*.*'
-                    ]
-                }
-            }
-        },
-
-        // Reads HTML for usemin blocks to enable smart builds that automatically
-        // concat, minify and revision files. Creates configurations in memory so
-        // additional tasks can operate on them
-        useminPrepare: {
-            options: {
-                dest: '<%%= yeoman.dist %>'
-            },
-            html: '<%%= yeoman.app %>/index.html'
-        },
-
-        // Performs rewrites based on rev and the useminPrepare configuration
-        usemin: {
-            options: {
-                assetsDirs: ['<%%= yeoman.dist %>']
-            },
-            html: ['<%%= yeoman.dist %>/{,*/}*.html'],
-            css: ['<%%= yeoman.dist %>/styles/{,*/}*.css']
-        },
-
-        // The following *-min tasks produce minified files in the dist folder
-        imagemin: {
-            dist: {
-                files: [{
-                    expand: true,
-                    cwd: '<%%= yeoman.app %>/images',
-                    src: '{,*/}*.{gif,jpeg,jpg,png}',
-                    dest: '<%%= yeoman.dist %>/images'
-                }]
-            }
-        },
-        svgmin: {
-            dist: {
-                files: [{
-                    expand: true,
-                    cwd: '<%%= yeoman.app %>/images',
-                    src: '{,*/}*.svg',
-                    dest: '<%%= yeoman.dist %>/images'
-                }]
-            }
-        },
-        htmlmin: {
-            dist: {
-                options: {
-                    collapseBooleanAttributes: true,
-                    collapseWhitespace: true,
-                    removeAttributeQuotes: true,
-                    removeCommentsFromCDATA: true,
-                    removeEmptyAttributes: true,
-                    removeOptionalTags: true,
-                    removeRedundantAttributes: true,
-                    useShortDoctype: true
-                },
-                files: [{
-                    expand: true,
-                    cwd: '<%%= yeoman.dist %>',
-                    src: '{,*/}*.html',
-                    dest: '<%%= yeoman.dist %>'
-                }]
-            }
-        },
-
-        // By default, your `index.html`'s <!-- Usemin block --> will take care of
-        // minification. These next options are pre-configured if you do not wish
-        // to use the Usemin blocks.
-        // cssmin: {
-        //     dist: {
-        //         files: {
-        //             '<%%= yeoman.dist %>/styles/main.css': [
-        //                 '.tmp/styles/{,*/}*.css',
-        //                 '<%%= yeoman.app %>/styles/{,*/}*.css'
-        //             ]
-        //         }
-        //     }
-        // },
-        // uglify: {
-        //     dist: {
-        //         files: {
-        //             '<%%= yeoman.dist %>/scripts/scripts.js': [
-        //                 '<%%= yeoman.dist %>/scripts/scripts.js'
-        //             ]
-        //         }
-        //     }
-        // },
-        // concat: {
-        //     dist: {}
-        // },
-
-        // Copies remaining files to places other tasks can use
-        copy: {
-            dist: {
-                files: [{
-                    expand: true,
-                    dot: true,
-                    cwd: '<%%= yeoman.app %>',
-                    dest: '<%%= yeoman.dist %>',
-                    src: [
-                        '*.{ico,png,txt}',
-                        '.htaccess',
-                        'images/{,*/}*.webp',
-                        '{,*/}*.html',
-                        'styles/fonts/{,*/}*.*'<% if (includeBootstrap) { %>,
-                        'bower_components/' + (this.includeCompass ? 'sass-' : '') + 'bootstrap/' + (this.includeCompass ? 'fonts/' : 'dist/fonts/') +'*.*'<% } %>
-                    ]
-                }]
-            },
-            styles: {
-                expand: true,
-                dot: true,
-                cwd: '<%%= yeoman.app %>/styles',
-                dest: '.tmp/styles/',
-                src: '{,*/}*.css'
-            }
-        },
-
-<% if (includeModernizr) { %>
-        // Generates a custom Modernizr build that includes only the tests you
-        // reference in your app
-        modernizr: {
-            devFile: '<%%= yeoman.app %>/bower_components/modernizr/modernizr.js',
-            outputFile: '<%%= yeoman.dist %>/bower_components/modernizr/modernizr.js',
-            files: [
-                '<%%= yeoman.dist %>/scripts/{,*/}*.js',
-                '<%%= yeoman.dist %>/styles/{,*/}*.css',
-                '!<%%= yeoman.dist %>/scripts/vendor/*'
-            ],
-            uglify: true
-        },<% } %>
-
-        // Run some tasks in parallel to speed up build process
-        concurrent: {
-            server: [<% if (includeCompass) { %>
-                'compass:server',<% } if (coffee) { %>
-                'coffee:dist',<% } %>
-                'copy:styles'
-            ],
-            test: [<% if (coffee) { %>
-                'coffee',<% } %>
-                'copy:styles'
-            ],
-            dist: [<% if (coffee) { %>
-                'coffee',<% } if (includeCompass) { %>
-                'compass',<% } %>
-                'copy:styles',
-                'imagemin',
-                'svgmin'
-            ]
         }
-    });
+    }
+
+    // Define the configuration for all the tasks
+    grunt.util._.extend(config, loadConfig('./grunt/'));
+
+    grunt.initConfig(config);
 
 
     grunt.registerTask('serve', function (target) {

--- a/app/templates/grunt/autoprefixer.js
+++ b/app/templates/grunt/autoprefixer.js
@@ -1,0 +1,15 @@
+'use strict';
+// Add vendor prefixed styles
+module.exports = {
+    options: {
+        browsers: ['last 1 version']
+    },
+    dist: {
+        files: [{
+            expand: true,
+            cwd: '.tmp/styles/',
+            src: '{,*/}*.css',
+            dest: '.tmp/styles/'
+        }]
+    }
+};

--- a/app/templates/grunt/bower-install.js
+++ b/app/templates/grunt/bower-install.js
@@ -1,0 +1,8 @@
+'use strict';
+// Automatically inject Bower components into the HTML file
+module.exports = {
+    app: {
+        html: '<%%= yeoman.app %>/index.html',
+        ignorePath: '<%%= yeoman.app %>/'
+    }
+};

--- a/app/templates/grunt/clean.js
+++ b/app/templates/grunt/clean.js
@@ -1,0 +1,15 @@
+'use strict';
+// Empties folders to start fresh
+module.exports = {
+    dist: {
+        files: [{
+            dot: true,
+            src: [
+                '.tmp',
+                '<%%= yeoman.dist %>/*',
+                '!<%%= yeoman.dist %>/.git*'
+            ]
+        }]
+    },
+    server: '.tmp'
+};

--- a/app/templates/grunt/coffee.js
+++ b/app/templates/grunt/coffee.js
@@ -1,0 +1,22 @@
+'use strict';
+// Compiles CoffeeScript to JavaScript
+module.exports = {
+    dist: {
+        files: [{
+            expand: true,
+            cwd: '<%%= yeoman.app %>/scripts',
+            src: '{,*/}*.{coffee,litcoffee,coffee.md}',
+            dest: '.tmp/scripts',
+            ext: '.js'
+        }]
+    },
+    test: {
+        files: [{
+            expand: true,
+            cwd: 'test/spec',
+            src: '{,*/}*.{coffee,litcoffee,coffee.md}',
+            dest: '.tmp/spec',
+            ext: '.js'
+        }]
+    }
+};

--- a/app/templates/grunt/compass.js
+++ b/app/templates/grunt/compass.js
@@ -1,0 +1,28 @@
+'use strict';
+// Compiles Sass to CSS and generates necessary files if requested
+module.exports = {
+    options: {
+        sassDir: '<%%= yeoman.app %>/styles',
+        cssDir: '.tmp/styles',
+        generatedImagesDir: '.tmp/images/generated',
+        imagesDir: '<%%= yeoman.app %>/images',
+        javascriptsDir: '<%%= yeoman.app %>/scripts',
+        fontsDir: '<%%= yeoman.app %>/styles/fonts',
+        importPath: '<%%= yeoman.app %>/bower_components',
+        httpImagesPath: '/images',
+        httpGeneratedImagesPath: '/images/generated',
+        httpFontsPath: '/styles/fonts',
+        relativeAssets: false,
+        assetCacheBuster: false
+    },
+    dist: {
+        options: {
+            generatedImagesDir: '<%%= yeoman.dist %>/images/generated'
+        }
+    },
+    server: {
+        options: {
+            debugInfo: true
+        }
+    }
+};

--- a/app/templates/grunt/concurrent.js
+++ b/app/templates/grunt/concurrent.js
@@ -1,0 +1,20 @@
+'use strict';
+// Run some tasks in parallel to speed up build process
+module.exports = {
+    server: [<% if (includeCompass) { %>
+        'compass:server',<% } if (coffee) { %>
+        'coffee:dist',<% } %>
+        'copy:styles'
+    ],
+    test: [<% if (coffee) { %>
+        'coffee',<% } %>
+        'copy:styles'
+    ],
+    dist: [<% if (coffee) { %>
+        'coffee',<% } if (includeCompass) { %>
+        'compass',<% } %>
+        'copy:styles',
+        'imagemin',
+        'svgmin'
+    ]
+};

--- a/app/templates/grunt/connect.js
+++ b/app/templates/grunt/connect.js
@@ -1,0 +1,36 @@
+'use strict';
+// The actual grunt server settings
+module.exports = {
+    options: {
+        port: 9000,
+        livereload: 35729,
+        // Change this to '0.0.0.0' to access the server from outside
+        hostname: 'localhost'
+    },
+    livereload: {
+        options: {
+            open: true,
+            base: [
+                '.tmp',
+                '<%%= yeoman.app %>'
+            ]
+        }
+    },
+    test: {
+        options: {
+            port: 9001,
+            base: [
+                '.tmp',
+                'test',
+                '<%%= yeoman.app %>'
+            ]
+        }
+    },
+    dist: {
+        options: {
+            open: true,
+            base: '<%%= yeoman.dist %>',
+            livereload: false
+        }
+    }
+};

--- a/app/templates/grunt/copy.js
+++ b/app/templates/grunt/copy.js
@@ -1,0 +1,27 @@
+'use strict';
+// Copies remaining files to places other tasks can use
+module.exports = {
+    dist: {
+        files: [{
+            expand: true,
+            dot: true,
+            cwd: '<%%= yeoman.app %>',
+            dest: '<%%= yeoman.dist %>',
+            src: [
+                '*.{ico,png,txt}',
+                '.htaccess',
+                'images/{,*/}*.webp',
+                '{,*/}*.html',
+                'styles/fonts/{,*/}*.*'<% if (includeBootstrap) { %>,
+                'bower_components/' + (this.includeCompass ? 'sass-' : '') + 'bootstrap/' + (this.includeCompass ? 'fonts/' : 'dist/fonts/') +'*.*'<% } %>
+            ]
+        }]
+    },
+    styles: {
+        expand: true,
+        dot: true,
+        cwd: '<%%= yeoman.app %>/styles',
+        dest: '.tmp/styles/',
+        src: '{,*/}*.css'
+    }
+};

--- a/app/templates/grunt/htmlmin.js
+++ b/app/templates/grunt/htmlmin.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+    dist: {
+        options: {
+            collapseBooleanAttributes: true,
+            collapseWhitespace: true,
+            removeAttributeQuotes: true,
+            removeCommentsFromCDATA: true,
+            removeEmptyAttributes: true,
+            removeOptionalTags: true,
+            removeRedundantAttributes: true,
+            useShortDoctype: true
+        },
+        files: [{
+            expand: true,
+            cwd: '<%%= yeoman.dist %>',
+            src: '{,*/}*.html',
+            dest: '<%%= yeoman.dist %>'
+        }]
+    }
+};

--- a/app/templates/grunt/imagemin.js
+++ b/app/templates/grunt/imagemin.js
@@ -1,0 +1,12 @@
+'use strict';
+// The following *-min tasks produce minified files in the dist folder
+module.exports = {
+    dist: {
+        files: [{
+            expand: true,
+            cwd: '<%%= yeoman.app %>/images',
+            src: '{,*/}*.{gif,jpeg,jpg,png}',
+            dest: '<%%= yeoman.dist %>/images'
+        }]
+    }
+};

--- a/app/templates/grunt/jasmine.js
+++ b/app/templates/grunt/jasmine.js
@@ -1,0 +1,9 @@
+'use strict';
+// Jasmine testing framework configuration options
+module.exports = {
+    all: {
+        options: {
+            specs: 'test/spec/{,*/}*.js'
+        }
+    }
+};

--- a/app/templates/grunt/jshint.js
+++ b/app/templates/grunt/jshint.js
@@ -1,0 +1,14 @@
+'use strict';
+// Make sure code styles are up to par and there are no obvious mistakes
+module.exports = {
+    options: {
+        jshintrc: '.jshintrc',
+        reporter: require('jshint-stylish')
+    },
+    all: [
+        'Gruntfile.js',
+        '<%%= yeoman.app %>/scripts/{,*/}*.js',
+        '!<%%= yeoman.app %>/scripts/vendor/*',
+        'test/spec/{,*/}*.js'
+    ]
+};

--- a/app/templates/grunt/mocha.js
+++ b/app/templates/grunt/mocha.js
@@ -1,0 +1,10 @@
+'use strict';
+// Mocha testing framework configuration options
+module.exports = {
+    all: {
+        options: {
+            run: true,
+            urls: ['http://<%%= connect.test.options.hostname %>:<%%= connect.test.options.port %>/index.html']
+        }
+    }
+};

--- a/app/templates/grunt/modernizr.js
+++ b/app/templates/grunt/modernizr.js
@@ -1,0 +1,13 @@
+'use strict';
+// Generates a custom Modernizr build that includes only the tests you
+// reference in your app
+module.exports = {
+    devFile: '<%%= yeoman.app %>/bower_components/modernizr/modernizr.js',
+    outputFile: '<%%= yeoman.dist %>/bower_components/modernizr/modernizr.js',
+    files: [
+        '<%%= yeoman.dist %>/scripts/{,*/}*.js',
+        '<%%= yeoman.dist %>/styles/{,*/}*.css',
+        '!<%%= yeoman.dist %>/scripts/vendor/*'
+    ],
+    uglify: true
+};

--- a/app/templates/grunt/rev.js
+++ b/app/templates/grunt/rev.js
@@ -1,0 +1,14 @@
+'use strict';
+// Renames files for browser caching purposes
+module.exports = {
+    dist: {
+        files: {
+            src: [
+                '<%%= yeoman.dist %>/scripts/{,*/}*.js',
+                '<%%= yeoman.dist %>/styles/{,*/}*.css',
+                '<%%= yeoman.dist %>/images/{,*/}*.{gif,jpeg,jpg,png,webp}',
+                '<%%= yeoman.dist %>/styles/fonts/{,*/}*.*'
+            ]
+        }
+    }
+};

--- a/app/templates/grunt/svgmin.js
+++ b/app/templates/grunt/svgmin.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = {
+    dist: {
+        files: [{
+            expand: true,
+            cwd: '<%%= yeoman.app %>/images',
+            src: '{,*/}*.svg',
+            dest: '<%%= yeoman.dist %>/images'
+        }]
+    }
+};

--- a/app/templates/grunt/usemin.js
+++ b/app/templates/grunt/usemin.js
@@ -1,0 +1,9 @@
+'use strict';
+// Performs rewrites based on rev and the useminPrepare configuration
+module.exports = {
+    options: {
+        assetsDirs: ['<%%= yeoman.dist %>']
+    },
+    html: ['<%%= yeoman.dist %>/{,*/}*.html'],
+    css: ['<%%= yeoman.dist %>/styles/{,*/}*.css']
+};

--- a/app/templates/grunt/useminPrepare.js
+++ b/app/templates/grunt/useminPrepare.js
@@ -1,0 +1,10 @@
+'use strict';
+// Reads HTML for usemin blocks to enable smart builds that automatically
+// concat, minify and revision files. Creates configurations in memory so
+// additional tasks can operate on them
+module.exports = {
+    options: {
+        dest: '<%%= yeoman.dist %>'
+    },
+    html: '<%%= yeoman.app %>/index.html'
+};

--- a/app/templates/grunt/watch.js
+++ b/app/templates/grunt/watch.js
@@ -1,0 +1,45 @@
+'use strict';
+// Watches files for changes and runs tasks based on the changed files
+module.exports = {<% if (coffee) { %>
+    coffee: {
+        files: ['<%%= yeoman.app %>/scripts/{,*/}*.{coffee,litcoffee,coffee.md}'],
+        tasks: ['coffee:dist']
+    },
+    coffeeTest: {
+        files: ['test/spec/{,*/}*.{coffee,litcoffee,coffee.md}'],
+        tasks: ['coffee:test', 'test:watch']
+    },<% } else { %>
+    js: {
+        files: ['<%%= yeoman.app %>/scripts/{,*/}*.js'],
+        tasks: ['jshint'],
+        options: {
+            livereload: true
+        }
+    },
+    jstest: {
+        files: ['test/spec/{,*/}*.js'],
+        tasks: ['test:watch']
+    },<% } %>
+    gruntfile: {
+        files: ['Gruntfile.js']
+    },<% if (includeCompass) { %>
+    compass: {
+        files: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
+        tasks: ['compass:server', 'autoprefixer']
+    },<% } %>
+    styles: {
+        files: ['<%%= yeoman.app %>/styles/{,*/}*.css'],
+        tasks: ['newer:copy:styles', 'autoprefixer']
+    },
+    livereload: {
+        options: {
+            livereload: '<%%= connect.options.livereload %>'
+        },
+        files: [
+            '<%%= yeoman.app %>/{,*/}*.html',
+            '.tmp/styles/{,*/}*.css',<% if (coffee) { %>
+            '.tmp/scripts/{,*/}*.js',<% } %>
+            '<%%= yeoman.app %>/images/{,*/}*.{gif,jpeg,jpg,png,svg,webp}'
+        ]
+    }
+};

--- a/app/templates/gruntrc
+++ b/app/templates/gruntrc
@@ -1,0 +1,3 @@
+{
+    "directory": "grunt"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -31,13 +31,34 @@ describe('Webapp generator test', function () {
     var expected = [
       ['bower.json', /"name": "temp"/],
       ['package.json', /"name": "temp"/],
-      ['Gruntfile.js', /coffee:/],
+      'Gruntfile.js',
+      'grunt/autoprefixer.js',
+      'grunt/bower-install.js',
+      'grunt/clean.js',
+      'grunt/coffee.js',
+      'grunt/compass.js',
+      'grunt/concurrent.js',
+      'grunt/connect.js',
+      'grunt/copy.js',
+      'grunt/htmlmin.js',
+      'grunt/jshint.js',
+      'grunt/mocha.js',
+      'grunt/rev.js',
+      'grunt/svgmin.js',
+      'grunt/usemin.js',
+      'grunt/useminPrepare.js',
+      'grunt/watch.js',
       'app/404.html',
       'app/favicon.ico',
       'app/robots.txt',
       'app/index.html',
       'app/scripts/main.coffee',
       'app/styles/main.scss'
+    ];
+
+    var notExpected = [
+      'grunt/jasmine.js',
+      'grunt/modernizr.js'
     ];
 
     helpers.mockPrompt(this.webapp, {
@@ -48,6 +69,7 @@ describe('Webapp generator test', function () {
     this.webapp.options['skip-install'] = true;
     this.webapp.run({}, function () {
       helpers.assertFiles(expected);
+      helpers.assertNoFile(notExpected);
       done();
     });
   });
@@ -57,12 +79,32 @@ describe('Webapp generator test', function () {
       ['bower.json', /"name": "temp"/],
       ['package.json', /"name": "temp"/],
       'Gruntfile.js',
+      'grunt/autoprefixer.js',
+      'grunt/bower-install.js',
+      'grunt/clean.js',
+      'grunt/compass.js',
+      'grunt/concurrent.js',
+      'grunt/connect.js',
+      'grunt/copy.js',
+      'grunt/htmlmin.js',
+      'grunt/jshint.js',
+      'grunt/mocha.js',
+      'grunt/rev.js',
+      'grunt/svgmin.js',
+      'grunt/usemin.js',
+      'grunt/useminPrepare.js',
+      'grunt/watch.js',
       'app/404.html',
       'app/favicon.ico',
       'app/robots.txt',
       'app/index.html',
       'app/scripts/main.js',
       'app/styles/main.scss'
+    ];
+    var notExpected = [
+      'grunt/coffee.js',
+      'grunt/jasmine.js',
+      'grunt/modernizr.js'
     ];
 
     helpers.mockPrompt(this.webapp, {
@@ -73,6 +115,7 @@ describe('Webapp generator test', function () {
     this.webapp.options['skip-install'] = true;
     this.webapp.run({}, function () {
       helpers.assertFiles(expected);
+      helpers.assertNoFile(notExpected);
       done();
     });
   });
@@ -82,6 +125,21 @@ describe('Webapp generator test', function () {
       ['bower.json', /"name": "temp"/],
       ['package.json', /"name": "temp"/],
       'Gruntfile.js',
+      'grunt/autoprefixer.js',
+      'grunt/bower-install.js',
+      'grunt/clean.js',
+      'grunt/compass.js',
+      'grunt/concurrent.js',
+      'grunt/connect.js',
+      'grunt/copy.js',
+      'grunt/htmlmin.js',
+      'grunt/jshint.js',
+      'grunt/mocha.js',
+      'grunt/rev.js',
+      'grunt/svgmin.js',
+      'grunt/usemin.js',
+      'grunt/useminPrepare.js',
+      'grunt/watch.js',
       'app/404.html',
       'app/favicon.ico',
       'app/robots.txt',
@@ -89,7 +147,12 @@ describe('Webapp generator test', function () {
       'app/scripts/main.js',
       'app/styles/main.scss'
     ];
-
+    var notExpected = [
+      'grunt/coffee.js',
+      'grunt/jasmine.js',
+      'grunt/modernizr.js'
+    ];
+    
     helpers.mockPrompt(this.webapp, {
       features: ['includeCompass']
     });
@@ -97,6 +160,7 @@ describe('Webapp generator test', function () {
     this.webapp.options['skip-install'] = true;
     this.webapp.run({}, function () {
       helpers.assertFiles(expected);
+      helpers.assertNoFile(notExpected);
       done();
     });
   });


### PR DESCRIPTION
Grunt files tend to grow huge and illegible **very** fast, it would be a real improvement if the task configurations would be separated to files. I chose for a `grunt` directory to add all config files to, but maybe that's not the best choice.

The loadConfig function was copied from https://gist.github.com/thomasboyt/6406507#file-load_config-js, I added a comment as attribution, but I don't know if that's good practice.

Hope you guys accept this one, because the monolithic grunt files drive me crazy :wink: 
