### PR TITLE
Pass target through from deprecated server task

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -407,9 +407,15 @@ module.exports = function (grunt) {
         ]);
     });
 
-    grunt.registerTask('server', function () {
+    grunt.registerTask('server', function (target) {
         grunt.log.warn('The `server` task has been deprecated. Use `grunt serve` to start a server.');
-        grunt.task.run(['serve']);
+
+        if (target) {
+            grunt.task.run(['serve:' + target]);
+        }
+        else {
+            grunt.task.run(['serve']);
+        }
     });
 
     grunt.registerTask('test', function(target) {


### PR DESCRIPTION
So `grunt server:dist` does not incorrectly proxy to `grunt serve`.
