### PR TITLE
Update time-grunt

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -27,7 +27,7 @@
     "grunt-svgmin": "~0.2.0",
     "grunt-concurrent": "~0.4.0",
     "load-grunt-tasks": "~0.2.0",
-    "time-grunt": "~0.2.0",
+    "time-grunt": "~0.2.9",
     "jshint-stylish": "~0.1.3"
   },
   "engines": {


### PR DESCRIPTION
`time-grunt` had a bug (sindresorhus/time-grunt#29) caused by early
exit, which broke some useful stuff like `grunt --help`.
