### PR TITLE
Fix Bootstrap font paths

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -345,7 +345,9 @@ module.exports = function (grunt) {
                         'images/{,*/}*.webp',
                         '{,*/}*.html',
                         'styles/fonts/{,*/}*.*'<% if (includeBootstrap) { %>,
-                        'bower_components/bootstrap' + (this.includeCompass ? '-sass/' : '/') + (this.includeCompass ? 'vendor/assets/fonts/bootstrap/' : 'dist/fonts/') +'*.*'<% } %>
+                        <% if (includeCompass) {
+                        %>'bower_components/bootstrap-sass/vendor/assets/fonts/bootstrap/*.*'<% } else {
+                        %>'bower_components/bootstrap/dist/fonts/*.*'<% } } %>
                     ]
                 }]
             },

--- a/app/templates/main.scss
+++ b/app/templates/main.scss
@@ -1,4 +1,4 @@
-<% if (includeBootstrap) { %>$icon-font-path: "/bower_components/bootstrap-sass/vender/assets/fonts/";
+<% if (includeBootstrap) { %>$icon-font-path: "/bower_components/bootstrap-sass/vendor/assets/fonts/";
 
 @import 'bootstrap-sass/vendor/assets/stylesheets/bootstrap';
 
@@ -83,7 +83,7 @@ body {
     .header {
         margin-bottom: 30px;
     }
-    
+
     /* Remove the bottom border on the jumbotron for visual effect */
     .jumbotron {
         border-bottom: 0;


### PR DESCRIPTION
This fixes the wrong output in the Gruntfile concerning Bootstrap fonts (#259). One question, though, what is this variable for?

``` scss
$icon-font-path: "/bower_components/bootstrap-sass/vendor/assets/fonts/";
```

It seems completely useless because there's already a Bootstrap partial which imports the Glyphicons. May I delete it?
