### PR TITLE
Include Normalize.css if Bootstrap is not present

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -3,7 +3,8 @@
   "private": true,
   "dependencies": {<% if (includeBootstrap) { if (includeCompass) { %>
     "bootstrap-sass": "git://github.com/twbs/bootstrap-sass.git#v3.1.0",<% } else { %>
-    "bootstrap": "~3.0.3",<% }} if (includeModernizr) { %>
+    "bootstrap": "~3.0.3",<% }} else { %>
+    "normalize-css": "~3.0.0",<% } if (includeModernizr) { %>
     "modernizr": "~2.6.2",<% } %>
     "jquery": "~1.10.2"
   },

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,7 +11,8 @@
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
         <!-- build:css styles/vendor.css -->
         <!-- bower:css -->
-        <% if (includeBootstrap && !includeCompass) { %><link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.min.css"><% } %>
+        <% if (includeBootstrap && !includeCompass) { %><link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.min.css"><% }
+        else if (!includeBootstrap) { %><link rel="stylesheet" href="bower_components/normalize-css/normalize.css" /><% } %>
         <!-- endbower -->
         <!-- endbuild -->
         <!-- build:css(.tmp) styles/main.css -->

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -8,13 +8,17 @@
         <title><%= appname %></title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
-        <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+        <!-- Place favicon.ico and apple-touch-icon.png in the root directory --><% if (!includeBootstrap) { %>
         <!-- build:css styles/vendor.css -->
         <!-- bower:css -->
-        <% if (includeBootstrap && !includeCompass) { %><link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.min.css"><% }
-        else if (!includeBootstrap) { %><link rel="stylesheet" href="bower_components/normalize-css/normalize.css" /><% } %>
+        <link rel="stylesheet" href="bower_components/normalize-css/normalize.css">
         <!-- endbower -->
-        <!-- endbuild -->
+        <!-- endbuild --><% } else if (includeBootstrap && !includeCompass) { %>
+        <!-- build:css styles/vendor.css -->
+        <!-- bower:css -->
+        <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.min.css">
+        <!-- endbower -->
+        <!-- endbuild --><% } %>
         <!-- build:css(.tmp) styles/main.css -->
         <link rel="stylesheet" href="styles/main.css">
         <!-- endbuild --><% if (includeModernizr) { %>


### PR DESCRIPTION
I included it instead of Bootstrap because Bootstrap already ships with Normalize. What do we do in the case when Sass & Compass are also present? Because then both Bootstrap and Normalize aren't included, which leaves `vendor.css` empty again. :worried:

Also, do I add Normalize to the description `Out of the box I include...` or is it unnecessary because Normalize is part of H5BP anyway?

This should fix #242 once it's resolved.
