### PR TITLE
update jquery to 1.11.0

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -5,7 +5,7 @@
     "bootstrap-sass": "git://github.com/twbs/bootstrap-sass.git#v3.1.0",<% } else { %>
     "bootstrap": "~3.0.3",<% }} if (includeModernizr) { %>
     "modernizr": "~2.6.2",<% } %>
-    "jquery": "~1.10.2"
+    "jquery": "~1.11.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
update jquery to 1.11.0, so there is no `event.returnValue is deprecated. Please use the standard event.preventDefault() instead.` warning by default.
