### PR TITLE
upgrade bower-install to 1.0

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -133,9 +133,8 @@ module.exports = function (grunt) {
                 '!<%%= yeoman.app %>/scripts/vendor/*',
                 'test/spec/{,*/}*.js'
             ]
-        },
+        },<% if (testFramework === 'mocha') { %>
 
-<% if (testFramework === 'mocha') { %>
         // Mocha testing framework configuration options
         mocha: {
             all: {
@@ -145,6 +144,7 @@ module.exports = function (grunt) {
                 }
             }
         },<% } else if (testFramework === 'jasmine') { %>
+
         // Jasmine testing framework configuration options
         jasmine: {
             all: {
@@ -152,9 +152,8 @@ module.exports = function (grunt) {
                     specs: 'test/spec/{,*/}*.js'
                 }
             }
-        },<% } %>
+        },<% } %><% if (coffee) { %>
 
-<% if (coffee) { %>
         // Compiles CoffeeScript to JavaScript
         coffee: {
             dist: {
@@ -175,9 +174,8 @@ module.exports = function (grunt) {
                     ext: '.js'
                 }]
             }
-        },<% } %>
+        },<% } %><% if (includeCompass) { %>
 
-<% if (includeCompass) { %>
         // Compiles Sass to CSS and generates necessary files if requested
         compass: {
             options: {
@@ -222,12 +220,17 @@ module.exports = function (grunt) {
         },
 
         // Automatically inject Bower components into the HTML file
-        'bower-install': {
+        bowerInstall: {
             app: {
-                html: '<%%= yeoman.app %>/index.html',
-                ignorePath: '<%%= yeoman.app %>/',
-                exclude: [<% if (includeCompass) { %> '<%%= yeoman.app %>/bower_components/bootstrap-sass/vendor/assets/javascripts/bootstrap.js' <% } %>]
-            }
+                src: ['<%%= yeoman.app %>/index.html'],
+                ignorePath: '<%%= yeoman.app %>/'<% if (includeCompass) { %>,
+                exclude: ['<%%= yeoman.app %>/bower_components/bootstrap-sass/vendor/assets/javascripts/bootstrap.js']
+            },
+            sass: {
+                src: ['<%%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
+                ignorePath: '<%%= yeoman.app %>/bower_components/'
+            }<% } else { %>
+            }<% } %>
         },
 
         // Renames files for browser caching purposes
@@ -274,6 +277,7 @@ module.exports = function (grunt) {
                 }]
             }
         },
+
         svgmin: {
             dist: {
                 files: [{
@@ -284,6 +288,7 @@ module.exports = function (grunt) {
                 }]
             }
         },
+
         htmlmin: {
             dist: {
                 options: {
@@ -357,9 +362,8 @@ module.exports = function (grunt) {
                 dest: '.tmp/styles/',
                 src: '{,*/}*.css'
             }
-        },
+        },<% if (includeModernizr) { %>
 
-<% if (includeModernizr) { %>
         // Generates a custom Modernizr build that includes only the tests you
         // reference in your app
         modernizr: {

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -14,7 +14,7 @@
     "grunt-contrib-connect": "~0.5.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-htmlmin": "~0.1.3",
-    "grunt-bower-install": "~0.7.0",
+    "grunt-bower-install": "~1.0.0",
     "grunt-contrib-imagemin": "~0.5.0",
     "grunt-contrib-watch": "~0.5.2",<% if (testFramework === 'jasmine') { %>
     "grunt-contrib-jasmine": "~0.4.2",<% } %>

--- a/app/templates/main.scss
+++ b/app/templates/main.scss
@@ -1,6 +1,8 @@
 <% if (includeBootstrap) { %>$icon-font-path: "/bower_components/bootstrap-sass/vendor/assets/fonts/";
 
-@import 'bootstrap-sass/vendor/assets/stylesheets/bootstrap';
+// bower:scss
+@import 'bootstrap-sass/vendor/assets/stylesheets/bootstrap.scss';
+// endbower
 
 .browsehappy {
     margin: 0.2em 0;
@@ -88,7 +90,10 @@ body {
     .jumbotron {
         border-bottom: 0;
     }
-}<% } else { %>body {
+}<% } else { %>// bower:scss
+// endbower
+
+body {
     background: #fafafa;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     color: #333;


### PR DESCRIPTION
Yay! `bower-install` 1.0 is out! It now supports Sass files, is called `bowerInstall`, as opposed to `bower-install`, and has some other small config property changes. Give it a shot!
