### PR TITLE
Replace load-grunt-tasks with jit-grunt

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -10,7 +10,7 @@
 module.exports = function (grunt) {
 
     // Load grunt tasks automatically
-    require('load-grunt-tasks')(grunt);
+    require('jit-grunt')(grunt);
 
     // Time how long tasks take. Can help when optimizing build times
     require('time-grunt')(grunt);

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -10,7 +10,9 @@
 module.exports = function (grunt) {
 
     // Load grunt tasks automatically
-    require('jit-grunt')(grunt);
+    require('jit-grunt')(grunt,{
+        useminPrepare: 'grunt-usemin'
+    });
 
     // Time how long tasks take. Can help when optimizing build times
     require('time-grunt')(grunt);

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -26,9 +26,9 @@
     "grunt-newer": "~0.6.0",
     "grunt-svgmin": "~0.2.0",
     "grunt-concurrent": "~0.4.0",
-    "load-grunt-tasks": "~0.2.0",
     "time-grunt": "~0.2.0",
-    "jshint-stylish": "~0.1.3"
+    "jshint-stylish": "~0.1.3",
+    "jit-grunt": "~0.2.1"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
Jit-grunt is fantastic:

> A JIT(Just In Time) plugin loader for Grunt.

I.e. it only loads the plugins you need for the running tasks. It saves **a lot** of build time. My spikes show me 5x speed improvements.
