### PR TITLE
Fix Glyphicons path for Sass Bootstrap

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -41,7 +41,7 @@
             <div class="jumbotron">
                 <h1>'Allo, 'Allo!</h1>
                 <p class="lead">Always a pleasure scaffolding your apps.</p>
-                <p><a class="btn btn-lg btn-success" href="#">Splendid!</a></p>
+                <p><a class="btn btn-lg btn-success" href="#">Splendid! <span class="glyphicon glyphicon-ok"></span></a></p>
             </div>
 
             <div class="row marketing">
@@ -63,7 +63,7 @@
             </div>
 
             <div class="footer">
-                <p>♥ from the Yeoman team</p>
+              <p><span class="glyphicon glyphicon-heart"></span> from the Yeoman team</p>
             </div>
 
         </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -63,7 +63,7 @@
             </div>
 
             <div class="footer">
-              <p><span class="glyphicon glyphicon-heart"></span> from the Yeoman team</p>
+                <p><span class="glyphicon glyphicon-heart"></span> from the Yeoman team</p>
             </div>
 
         </div>

--- a/app/templates/main.scss
+++ b/app/templates/main.scss
@@ -1,4 +1,4 @@
-<% if (includeBootstrap) { %>$icon-font-path: "/bower_components/bootstrap-sass/vendor/assets/fonts/";
+<% if (includeBootstrap) { %>$icon-font-path: "/bower_components/bootstrap-sass/vendor/assets/fonts/bootstrap/";
 
 // bower:scss
 @import 'bootstrap-sass/vendor/assets/stylesheets/bootstrap.scss';


### PR DESCRIPTION
I also added some icons to `index.html` so we can instantly see if Glyphicons loaded properly.
