### PR TITLE
Fix image revving

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -240,7 +240,7 @@ module.exports = function (grunt) {
                     src: [
                         '<%%= yeoman.dist %>/scripts/{,*/}*.js',
                         '<%%= yeoman.dist %>/styles/{,*/}*.css',
-                        '<%%= yeoman.dist %>/images/{,*/}*',
+                        '<%%= yeoman.dist %>/images/{,*/}*.*',
                         '<%%= yeoman.dist %>/styles/fonts/{,*/}*.*'
                     ]
                 }


### PR DESCRIPTION
`*` matches directories too, while `*.*` matches only files, which is what we want.
