### PR TITLE
Fix jQuery component path

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -81,7 +81,7 @@
 
         <!-- build:js scripts/vendor.js -->
         <!-- bower:js -->
-        <script src="bower_components/jquery/jquery.js"></script>
+        <script src="bower_components/jquery/dist/jquery.js"></script>
         <!-- endbower -->
         <!-- endbuild -->
 


### PR DESCRIPTION
In the index.html the path to jQuery is:

```
bower_components/jquery/jquery.js
```

However, I guess this recently changed. The correct path for the compiled version is now:

```
bower_components/jquery/dist/jquery.js
```
