### PR TITLE
Change prompt order, make Sass and Modernizr false by default

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -48,17 +48,17 @@ AppGenerator.prototype.askFor = function askFor() {
     name: 'features',
     message: 'What more would you like?',
     choices: [{
-      name: 'Sass with Compass',
-      value: 'includeCompass',
-      checked: true
-    }, {
       name: 'Bootstrap',
       value: 'includeBootstrap',
       checked: true
-    }, {
+    },{
+      name: 'Sass with Compass',
+      value: 'includeCompass',
+      checked: false
+    },{
       name: 'Modernizr',
       value: 'includeModernizr',
-      checked: true
+      checked: false
     }]
   }];
 


### PR DESCRIPTION
As discussed with @sindresorhus we think it would make sense to avoid developers opting for the kitchen-sink by giving them a lighter set of initial defaults. This PR:
- Moves Bootstrap up to the first prompt option
- Makes Sass and Modernizr false by default

Our plan is to eventually deprecate the 'Sass with Compass' option in favor of grunt-sass as it's significantly faster and we no longer consider Compass to offer as much value as we once did.
