### PR TITLE
use bowerInstall on `watch` task.

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -26,7 +26,11 @@ module.exports = function (grunt) {
         },
 
         // Watches files for changes and runs tasks based on the changed files
-        watch: {<% if (coffee) { %>
+        watch: {
+            bower: {
+                files: ['bower.json'],
+                tasks: ['bowerInstall']
+            },<% if (coffee) { %>
             coffee: {
                 files: ['<%%= config.app %>/scripts/{,*/}*.{coffee,litcoffee,coffee.md}'],
                 tasks: ['coffee:dist']


### PR DESCRIPTION
I stumbled upon this idea when integrating `wiredep` with `generator-gulp-webapp`. It kinda makes sense! If you `bower install` while `grunt watch` or `grunt serve`-ing, the `bowerInstall` task will run and update your files for you. Is this a good idea?
