### PR TITLE
Install bower_components in the root directory

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -122,7 +122,7 @@ AppGenerator.prototype.writeIndex = function writeIndex() {
 
   // wire Bootstrap plugins
   if (this.includeBootstrap) {
-    var bs = 'bower_components/bootstrap' + (this.includeCompass ? '-sass-official/vendor/assets/javascripts/bootstrap/' : '/js/');
+    var bs = '../bower_components/bootstrap' + (this.includeCompass ? '-sass-official/vendor/assets/javascripts/bootstrap/' : '/js/');
     this.indexFile = this.appendScripts(this.indexFile, 'scripts/plugins.js', [
       bs + 'affix.js',
       bs + 'alert.js',

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -235,13 +235,13 @@ module.exports = function (grunt) {
         bowerInstall: {
             app: {
                 src: ['<%%= config.app %>/index.html'],
-                ignorePath: '<%%= config.app %>/'<% if (includeCompass) { %>,
-                exclude: ['bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap.js']
-            },
+                ignorePath: '<%%= config.app %>/',<% if (includeCompass) { %>
+                exclude: ['bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap.js']<% } else { %>
+                exclude: ['bower_components/bootstrap/dist/js/bootstrap.js']<% } %>
+            }<% if (includeCompass) { %>,
             sass: {
                 src: ['<%%= config.app %>/styles/{,*/}*.{scss,sass}'],
                 ignorePath: '<%%= config.app %>/bower_components/'
-            }<% } else { %>
             }<% } %>
         },
 

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -15,15 +15,17 @@ module.exports = function (grunt) {
     // Time how long tasks take. Can help when optimizing build times
     require('time-grunt')(grunt);
 
+    // Configurable paths
+    var config = {
+        app: 'app',
+        dist: 'dist'
+    };
+
     // Define the configuration for all the tasks
     grunt.initConfig({
 
         // Project settings
-        config: {
-            // Configurable paths
-            app: 'app',
-            dist: 'dist'
-        },
+        config: config,
 
         // Watches files for changes and runs tasks based on the changed files
         watch: {
@@ -78,32 +80,38 @@ module.exports = function (grunt) {
         connect: {
             options: {
                 port: 9000,
+                open: true,
                 livereload: 35729,
                 // Change this to '0.0.0.0' to access the server from outside
                 hostname: 'localhost'
             },
             livereload: {
                 options: {
-                    open: true,
-                    base: [
-                        '.tmp',
-                        '<%%= config.app %>'
-                    ]
+                    middleware: function(connect) {
+                        return [
+                            connect.static('.tmp'),
+                            connect().use('/bower_components', connect.static('./bower_components')),
+                            connect.static(config.app)
+                        ]
+                    }
                 }
             },
             test: {
                 options: {
+                    open: false,
                     port: 9001,
-                    base: [
-                        '.tmp',
-                        'test',
-                        '<%%= config.app %>'
-                    ]
+                    middleware: function(connect) {
+                        return [
+                            connect.static('.tmp'),
+                            connect.static('test'),
+                            connect().use('/bower_components', connect.static('./bower_components')),
+                            connect.static(config.app)
+                        ]
+                    }
                 }
             },
             dist: {
                 options: {
-                    open: true,
                     base: '<%%= config.dist %>',
                     livereload: false
                 }
@@ -189,7 +197,7 @@ module.exports = function (grunt) {
                 imagesDir: '<%%= config.app %>/images',
                 javascriptsDir: '<%%= config.app %>/scripts',
                 fontsDir: '<%%= config.app %>/styles/fonts',
-                importPath: '<%%= config.app %>/bower_components',
+                importPath: './bower_components',
                 httpImagesPath: '/images',
                 httpGeneratedImagesPath: '/images/generated',
                 httpFontsPath: '/styles/fonts',
@@ -228,7 +236,7 @@ module.exports = function (grunt) {
             app: {
                 src: ['<%%= config.app %>/index.html'],
                 ignorePath: '<%%= config.app %>/'<% if (includeCompass) { %>,
-                exclude: ['<%%= config.app %>/bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap.js']
+                exclude: ['./bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap.js']
             },
             sass: {
                 src: ['<%%= config.app %>/styles/{,*/}*.{scss,sass}'],
@@ -354,11 +362,18 @@ module.exports = function (grunt) {
                         '.htaccess',
                         'images/{,*/}*.webp',
                         '{,*/}*.html',
-                        'styles/fonts/{,*/}*.*'<% if (includeBootstrap) { %>,<% if (includeCompass) { %>
-                        'bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/*.*'<% } else { %>
-                        'bower_components/bootstrap/dist/fonts/*.*'<% } %><% } %>
+                        'styles/fonts/{,*/}*.*'
                     ]
-                }]
+                }<% if (includeBootstrap) { %>, {
+                    expand: true,
+                    dot: true,
+                    cwd: '.',
+                    dest: '<%%= config.dist %>',
+                    src: [<% if (includeCompass) { %>
+                        'bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/*.*'<% } else { %>
+                        'bower_components/bootstrap/dist/fonts/*.*'<% } %>
+                    ]
+                }<% } %>]
             },
             styles: {
                 expand: true,
@@ -372,7 +387,7 @@ module.exports = function (grunt) {
         // Generates a custom Modernizr build that includes only the tests you
         // reference in your app
         modernizr: {
-            devFile: '<%%= config.app %>/bower_components/modernizr/modernizr.js',
+            devFile: './bower_components/modernizr/modernizr.js',
             outputFile: '<%%= config.dist %>/scripts/vendor/modernizr.js',
             files: [
                 '<%%= config.dist %>/scripts/{,*/}*.js',

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -236,7 +236,7 @@ module.exports = function (grunt) {
             app: {
                 src: ['<%%= config.app %>/index.html'],
                 ignorePath: '<%%= config.app %>/'<% if (includeCompass) { %>,
-                exclude: ['./bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap.js']
+                exclude: ['bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap.js']
             },
             sass: {
                 src: ['<%%= config.app %>/styles/{,*/}*.{scss,sass}'],
@@ -387,7 +387,7 @@ module.exports = function (grunt) {
         // Generates a custom Modernizr build that includes only the tests you
         // reference in your app
         modernizr: {
-            devFile: './bower_components/modernizr/modernizr.js',
+            devFile: 'bower_components/modernizr/modernizr.js',
             outputFile: '<%%= config.dist %>/scripts/vendor/modernizr.js',
             files: [
                 '<%%= config.dist %>/scripts/{,*/}*.js',

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -366,13 +366,12 @@ module.exports = function (grunt) {
                     ]
                 }<% if (includeBootstrap) { %>, {
                     expand: true,
-                    dot: true,
+                    dot: true,<% if (includeCompass) { %>
                     cwd: '.',
-                    dest: '<%%= config.dist %>',
-                    src: [<% if (includeCompass) { %>
-                        'bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/*.*'<% } else { %>
-                        'bower_components/bootstrap/dist/fonts/*.*'<% } %>
-                    ]
+                    src: ['bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/*.*'],<% } else { %>
+                    cwd: 'bower_components/bootstrap/dist',
+                    src: ['fonts/*.*'],<% } %>
+                    dest: '<%%= config.dist %>'
                 }<% } %>]
             },
             styles: {

--- a/app/templates/bowerrc
+++ b/app/templates/bowerrc
@@ -1,3 +1,3 @@
 {
-    "directory": "app/bower_components"
+    "directory": "bower_components"
 }

--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -2,5 +2,5 @@ node_modules
 dist
 .tmp
 .sass-cache
-app/bower_components
+bower_components
 test/bower_components

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,14 +12,14 @@
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
         <!-- build:css styles/vendor.css -->
         <!-- bower:css -->
-        <% if (includeBootstrap && !includeCompass) { %><link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.min.css"><% } %>
+        <% if (includeBootstrap && !includeCompass) { %><link rel="stylesheet" href="../bower_components/bootstrap/dist/css/bootstrap.css"><% } %>
         <!-- endbower -->
         <!-- endbuild -->
         <!-- build:css(.tmp) styles/main.css -->
         <link rel="stylesheet" href="styles/main.css">
         <!-- endbuild --><% if (includeModernizr) { %>
         <!-- build:js scripts/vendor/modernizr.js -->
-        <script src="bower_components/modernizr/modernizr.js"></script>
+        <script src="../bower_components/modernizr/modernizr.js"></script>
         <!-- endbuild -->
         <% } %>
     </head>
@@ -82,7 +82,7 @@
 
         <!-- build:js scripts/vendor.js -->
         <!-- bower:js -->
-        <script src="bower_components/jquery/dist/jquery.js"></script>
+        <script src="../bower_components/jquery/dist/jquery.js"></script>
         <!-- endbower -->
         <!-- endbuild -->
 


### PR DESCRIPTION
This is build on top of #263.

It seems something was fixed in the meantime (wiredep maybe) because grunt-bower-install is generating correct path (starting with `../bower_components`), so no ugly fixes were necessary.

I was paranoid and tested everything manually (on top of running tests), every path should now be correct :smile:
