### PR TITLE
Downgrade imagemin to a more stable version

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -15,7 +15,7 @@
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-htmlmin": "~0.1.3",
     "grunt-bower-install": "~1.0.0",
-    "grunt-contrib-imagemin": "~0.5.0",
+    "grunt-contrib-imagemin": "~0.4.1",
     "grunt-contrib-watch": "~0.5.2",<% if (testFramework === 'jasmine') { %>
     "grunt-contrib-jasmine": "~0.4.2",<% } %>
     "grunt-rev": "~0.1.0",


### PR DESCRIPTION
grunt-contrib-imagemin 0.5.0 randomly fails by throwing an error or generating empty images. gruntjs/grunt-contrib-imagemin#163
