### PR TITLE
Add option for Sass without Compass

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -52,26 +52,37 @@ AppGenerator.prototype.askFor = function askFor() {
       value: 'includeBootstrap',
       checked: true
     },{
-      name: 'Sass with Compass',
-      value: 'includeCompass',
+      name: 'Sass',
+      value: 'includeSass',
       checked: false
     },{
       name: 'Modernizr',
       value: 'includeModernizr',
       checked: false
     }]
+  }, {
+    when: function (answers) {
+      return answers.features.indexOf('includeSass') !== -1;
+    },
+    type: 'confirm',
+    name: 'libsass',
+    value: 'includeLibSass',
+    message: 'Would you like to use libsass? Read up more at \n' + chalk.green('https://github.com/yeoman/generator-webapp/blob/master/libsass.md'),
+    default: false
   }];
 
   this.prompt(prompts, function (answers) {
     var features = answers.features;
 
     function hasFeature(feat) { return features.indexOf(feat) !== -1; }
-
     // manually deal with the response, get back and store the results.
     // we change a bit this way of doing to automatically do this in the self.prompt() method.
-    this.includeCompass = hasFeature('includeCompass');
+    this.includeSass = hasFeature('includeSass');
     this.includeBootstrap = hasFeature('includeBootstrap');
     this.includeModernizr = hasFeature('includeModernizr');
+
+    this.includeLibSass = answers.libsass;
+    this.includeRubySass = !(answers.libsass);
 
     cb();
   }.bind(this));
@@ -111,7 +122,7 @@ AppGenerator.prototype.h5bp = function h5bp() {
 };
 
 AppGenerator.prototype.mainStylesheet = function mainStylesheet() {
-  var css = 'main.' + (this.includeCompass ? 's' : '') + 'css';
+  var css = 'main.' + (this.includeSass ? 's' : '') + 'css';
   this.copy(css, 'app/styles/' + css);
 };
 
@@ -122,7 +133,7 @@ AppGenerator.prototype.writeIndex = function writeIndex() {
 
   // wire Bootstrap plugins
   if (this.includeBootstrap) {
-    var bs = '../bower_components/bootstrap' + (this.includeCompass ? '-sass-official/vendor/assets/javascripts/bootstrap/' : '/js/');
+    var bs = '../bower_components/bootstrap' + (this.includeSass ? '-sass-official/vendor/assets/javascripts/bootstrap/' : '/js/');
     this.indexFile = this.appendScripts(this.indexFile, 'scripts/plugins.js', [
       bs + 'affix.js',
       bs + 'alert.js',

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -54,10 +54,10 @@ module.exports = function (grunt) {
             },<% } %>
             gruntfile: {
                 files: ['Gruntfile.js']
-            },<% if (includeCompass) { %>
-            compass: {
+            },<% if (includeSass) { %>
+            sass: {
                 files: ['<%%= config.app %>/styles/{,*/}*.{scss,sass}'],
-                tasks: ['compass:server', 'autoprefixer']
+                tasks: ['sass:server', 'autoprefixer']
             },<% } %>
             styles: {
                 files: ['<%%= config.app %>/styles/{,*/}*.css'],
@@ -186,33 +186,35 @@ module.exports = function (grunt) {
                     ext: '.js'
                 }]
             }
-        },<% } %><% if (includeCompass) { %>
+        },<% } %><% if (includeSass) { %>
 
         // Compiles Sass to CSS and generates necessary files if requested
-        compass: {
-            options: {
-                sassDir: '<%%= config.app %>/styles',
-                cssDir: '.tmp/styles',
-                generatedImagesDir: '.tmp/images/generated',
-                imagesDir: '<%%= config.app %>/images',
-                javascriptsDir: '<%%= config.app %>/scripts',
-                fontsDir: '<%%= config.app %>/styles/fonts',
-                importPath: './bower_components',
-                httpImagesPath: '/images',
-                httpGeneratedImagesPath: '/images/generated',
-                httpFontsPath: '/styles/fonts',
-                relativeAssets: false,
-                assetCacheBuster: false
+        sass: {
+            options: {<% if (includeLibSass) { %>
+                includePaths: [
+                    'bower_components'
+                ]<% } if (includeRubySass) { %>
+                loadPath: [
+                    'bower_components'
+                ]<% } %>
             },
             dist: {
-                options: {
-                    generatedImagesDir: '<%%= config.dist %>/images/generated'
-                }
+                files: [{
+                    expand: true,
+                    cwd: '<%%= config.app %>/styles',
+                    src: ['*.scss'],
+                    dest: '.tmp/styles',
+                    ext: '.css'
+                }]
             },
             server: {
-                options: {
-                    debugInfo: true
-                }
+                files: [{
+                    expand: true,
+                    cwd: '<%%= config.app %>/styles',
+                    src: ['*.scss'],
+                    dest: '.tmp/styles',
+                    ext: '.css'
+                }]
             }
         },<% } %>
 
@@ -235,10 +237,10 @@ module.exports = function (grunt) {
         bowerInstall: {
             app: {
                 src: ['<%%= config.app %>/index.html'],
-                ignorePath: '<%%= config.app %>/',<% if (includeCompass) { %>
+                ignorePath: '<%%= config.app %>/',<% if (includeSass) { %>
                 exclude: ['bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap.js']<% } else { %>
                 exclude: ['bower_components/bootstrap/dist/js/bootstrap.js']<% } %>
-            }<% if (includeCompass) { %>,
+            }<% if (includeSass) { %>,
             sass: {
                 src: ['<%%= config.app %>/styles/{,*/}*.{scss,sass}'],
                 ignorePath: '<%%= config.app %>/bower_components/'
@@ -366,7 +368,7 @@ module.exports = function (grunt) {
                     ]
                 }<% if (includeBootstrap) { %>, {
                     expand: true,
-                    dot: true,<% if (includeCompass) { %>
+                    dot: true,<% if (includeSass) { %>
                     cwd: '.',
                     src: ['bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/*.*'],<% } else { %>
                     cwd: 'bower_components/bootstrap/dist',
@@ -398,8 +400,8 @@ module.exports = function (grunt) {
 
         // Run some tasks in parallel to speed up build process
         concurrent: {
-            server: [<% if (includeCompass) { %>
-                'compass:server',<% } if (coffee) { %>
+            server: [<% if (includeSass) { %>
+                'sass:server',<% } if (coffee) {  %>
                 'coffee:dist',<% } %>
                 'copy:styles'
             ],
@@ -408,8 +410,8 @@ module.exports = function (grunt) {
                 'copy:styles'
             ],
             dist: [<% if (coffee) { %>
-                'coffee',<% } if (includeCompass) { %>
-                'compass',<% } %>
+                'coffee',<% } if (includeSass) { %>
+                'sass',<% } %>
                 'copy:styles',
                 'imagemin',
                 'svgmin'

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -1,7 +1,7 @@
 {
   "name": "<%= _.slugify(appname) %>",
   "private": true,
-  "dependencies": {<% if (includeBootstrap) { if (includeCompass) { %>
+  "dependencies": {<% if (includeBootstrap) { if (includeSass) { %>
     "bootstrap-sass-official": "~3.1.0",<% } else { %>
     "bootstrap": "~3.0.3",<% }} if (includeModernizr) { %>
     "modernizr": "~2.6.2",<% } %>

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -7,8 +7,9 @@
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-concat": "~0.3.0",<% if (coffee) { %>
     "grunt-contrib-coffee": "~0.10.1",<% } %>
-    "grunt-contrib-uglify": "~0.4.0",<% if (includeCompass) { %>
-    "grunt-contrib-compass": "~0.7.0",<% } %>
+    "grunt-contrib-uglify": "~0.4.0",<% if (includeSass) { %><% if (includeLibSass) { %>
+    "grunt-sass": "~0.11.0",<% } if (includeRubySass) { %>
+    "grunt-contrib-sass": "~0.7.3",<% } %><% } %>
     "grunt-contrib-jshint": "~0.9.2",
     "grunt-contrib-cssmin": "~0.9.0",
     "grunt-contrib-connect": "~0.7.1",

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,7 +12,7 @@
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
         <!-- build:css styles/vendor.css -->
         <!-- bower:css -->
-        <% if (includeBootstrap && !includeCompass) { %><link rel="stylesheet" href="../bower_components/bootstrap/dist/css/bootstrap.css"><% } %>
+        <% if (includeBootstrap && !includeSass) { %><link rel="stylesheet" href="../bower_components/bootstrap/dist/css/bootstrap.css"><% } %>
         <!-- endbower -->
         <!-- endbuild -->
         <!-- build:css(.tmp) styles/main.css -->
@@ -50,8 +50,8 @@
                     <h4>HTML5 Boilerplate</h4>
                     <p>HTML5 Boilerplate is a professional front-end template for building fast, robust, and adaptable web apps or sites.</p>
 
-                    <% if (includeCompass) { %><h4>Sass with Compass</h4>
-                    <p>Compass is an open-source CSS Authoring Framework that uses Sass.</p>
+                    <% if (includeSass) { %><h4>Sass</h4>
+                    <p>Sass is a mature, stable, and powerful professional grade CSS extension language.</p>
                     <% } %>
 
                     <h4>Bootstrap</h4>
@@ -74,7 +74,7 @@
           <p>You now have</p>
           <ul>
             <li>HTML5 Boilerplate</li>
-            <% if (includeCompass) { %><li>Sass with Compass</li><% } %>
+            <% if (includeSass) { %><li>Sass</li><% } %>
             <% if (includeModernizr) { %><li>Modernizr</li><% } %>
           </ul>
         </div>

--- a/libsass.md
+++ b/libsass.md
@@ -1,0 +1,4 @@
+#Libsass vs. Ruby sass
+
+Libsass is faster.
+Normal ruby sass supports more features.

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 
 * CSS Autoprefixing *(new)*
 * Built-in preview server with LiveReload
-* Automagically compile CoffeeScript & Compass
+* Automagically compile CoffeeScript & Sass
 * Automagically lint your scripts
 * Automagically wire up your Bower components with [bower-install](#third-party-dependencies).
 * Awesome Image Optimization (via OptiPNG, pngquant, jpegtran and gifsicle)

--- a/test/test.js
+++ b/test/test.js
@@ -41,7 +41,7 @@ describe('Webapp generator test', function () {
     ];
 
     helpers.mockPrompt(this.webapp, {
-      features: ['includeCompass']
+      features: ['includeSass']
     });
 
     this.webapp.coffee = true;
@@ -65,7 +65,7 @@ describe('Webapp generator test', function () {
     ];
 
     helpers.mockPrompt(this.webapp, {
-      features: ['includeCompass']
+      features: ['includeSass']
     });
 
     this.webapp.coffee = false;
@@ -89,7 +89,7 @@ describe('Webapp generator test', function () {
     ];
 
     helpers.mockPrompt(this.webapp, {
-      features: ['includeCompass']
+      features: ['includeSass']
     });
 
     this.webapp.run({}, function () {


### PR DESCRIPTION
I've implemented it such that you choose Sass. And then you're shown a confirm prompt asking if you want Compass. I've let the majority of the code remain the same in the templates the new Sass code is demarcated by `includeSass && !includeCompass`.

**Side by side comparisons**

Execution Time (2014-03-21 08:48:27 UTC)
    sass:server    342ms  98%
    Total 349ms

Execution Time (2014-03-21 08:47:20 UTC)
    compass:server  20.4s  100%
    Total 20.4s
