### PR TITLE
change format of modernizr task

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -387,16 +387,16 @@ module.exports = function (grunt) {
         // reference in your app
         modernizr: {
             dist: {
-                'devFile': '<%= yeoman.app %>/bower_components/modernizr/modernizr.js',
-                'outputFile': '<%= yeoman.dist %>/bower_components/modernizr/modernizr.js',
-                'files': {
-                    'src' : [
+                devFile: '<%= yeoman.app %>/bower_components/modernizr/modernizr.js',
+                outputFile: '<%= yeoman.dist %>/bower_components/modernizr/modernizr.js',
+                files: {
+                    src : [
                         '<%= yeoman.dist %>/scripts/{,*/}*.js',
                         '<%= yeoman.dist %>/styles/{,*/}*.css',
                         '!<%= yeoman.dist %>/scripts/vendor/*'
                     ]
                 },
-                'uglify': true
+                uglify: true
             }
         },<% } %>
 

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -386,14 +386,18 @@ module.exports = function (grunt) {
         // Generates a custom Modernizr build that includes only the tests you
         // reference in your app
         modernizr: {
-            devFile: 'bower_components/modernizr/modernizr.js',
-            outputFile: '<%%= config.dist %>/scripts/vendor/modernizr.js',
-            files: [
-                '<%%= config.dist %>/scripts/{,*/}*.js',
-                '<%%= config.dist %>/styles/{,*/}*.css',
-                '!<%%= config.dist %>/scripts/vendor/*'
-            ],
-            uglify: true
+            dist: {
+                'devFile': '<%= yeoman.app %>/bower_components/modernizr/modernizr.js',
+                'outputFile': '<%= yeoman.dist %>/bower_components/modernizr/modernizr.js',
+                'files': {
+                    'src' : [
+                        '<%= yeoman.dist %>/scripts/{,*/}*.js',
+                        '<%= yeoman.dist %>/styles/{,*/}*.css',
+                        '!<%= yeoman.dist %>/scripts/vendor/*'
+                    ]
+                },
+                'uglify': true
+            }
         },<% } %>
 
         // Run some tasks in parallel to speed up build process


### PR DESCRIPTION
grunt task `build` fails out of the box due to changes in how grunt-modernizr works. See https://github.com/Modernizr/grunt-modernizr#config-options and https://github.com/Modernizr/grunt-modernizr#devfile-string. The proposed changes allowed me to run `grunt` on a newly generated app with no warnings.
