### PR TITLE
templates _package.json updated to use latest version of all packages

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -4,33 +4,33 @@
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.1",
-    "grunt-contrib-copy": "~0.4.1",
+    "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-concat": "~0.3.0",<% if (coffee) { %>
-    "grunt-contrib-coffee": "~0.7.0",<% } %>
-    "grunt-contrib-uglify": "~0.2.0",<% if (includeCompass) { %>
+    "grunt-contrib-coffee": "~0.10.1",<% } %>
+    "grunt-contrib-uglify": "~0.4.0",<% if (includeCompass) { %>
     "grunt-contrib-compass": "~0.7.0",<% } %>
-    "grunt-contrib-jshint": "~0.7.0",
-    "grunt-contrib-cssmin": "~0.7.0",
-    "grunt-contrib-connect": "~0.5.0",
+    "grunt-contrib-jshint": "~0.9.2",
+    "grunt-contrib-cssmin": "~0.9.0",
+    "grunt-contrib-connect": "~0.7.1",
     "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-htmlmin": "~0.1.3",
-    "grunt-bower-install": "~1.0.0",
-    "grunt-contrib-imagemin": "~0.4.1",
-    "grunt-contrib-watch": "~0.5.2",<% if (testFramework === 'jasmine') { %>
-    "grunt-contrib-jasmine": "~0.4.2",<% } %>
+    "grunt-contrib-htmlmin": "~0.2.0",
+    "grunt-bower-install": "~1.4.0",
+    "grunt-contrib-imagemin": "~0.6.0",
+    "grunt-contrib-watch": "~0.6.1",<% if (testFramework === 'jasmine') { %>
+    "grunt-contrib-jasmine": "~0.6.3",<% } %>
     "grunt-rev": "~0.1.0",
-    "grunt-autoprefixer": "~0.5.0",
+    "grunt-autoprefixer": "~0.7.2",
     "grunt-usemin": "~2.1.0",<% if (testFramework === 'mocha') {  %>
-    "grunt-mocha": "~0.4.0",<% } %><% if (includeModernizr) { %>
-    "grunt-modernizr": "~0.4.0",<% } %>
-    "grunt-newer": "~0.6.0",
-    "grunt-svgmin": "~0.2.0",
-    "grunt-concurrent": "~0.4.0",
-    "load-grunt-tasks": "~0.2.0",
-    "time-grunt": "~0.2.0",
-    "jshint-stylish": "~0.1.3"
+    "grunt-mocha": "~0.4.10",<% } %><% if (includeModernizr) { %>
+    "grunt-modernizr": "~0.5.2",<% } %>
+    "grunt-newer": "~0.7.0",
+    "grunt-svgmin": "~0.4.0",
+    "grunt-concurrent": "~0.5.0",
+    "load-grunt-tasks": "~0.4.0",
+    "time-grunt": "~0.3.1",
+    "jshint-stylish": "~0.1.5"
   },
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=0.10.0"
   }
 }


### PR DESCRIPTION
required node version bumped to 0.10 because grunt-contrib-imagemin requires it. 
