### PR TITLE
Clean up bowerInstall

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -236,14 +236,12 @@ module.exports = function (grunt) {
         // Automatically inject Bower components into the HTML file
         bowerInstall: {
             app: {
-                src: ['<%%= config.app %>/index.html'],
-                ignorePath: '<%%= config.app %>/',<% if (includeSass) { %>
+                src: ['<%%= config.app %>/index.html'],<% if (includeSass) { %>
                 exclude: ['bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap.js']<% } else { %>
                 exclude: ['bower_components/bootstrap/dist/js/bootstrap.js']<% } %>
             }<% if (includeSass) { %>,
             sass: {
-                src: ['<%%= config.app %>/styles/{,*/}*.{scss,sass}'],
-                ignorePath: '<%%= config.app %>/bower_components/'
+                src: ['<%%= config.app %>/styles/{,*/}*.{scss,sass}']
             }<% } %>
         },
 

--- a/app/templates/main.scss
+++ b/app/templates/main.scss
@@ -1,7 +1,7 @@
 <% if (includeBootstrap) { %>$icon-font-path: "/bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/";
 
 // bower:scss
-@import 'bootstrap-sass-official/vendor/assets/stylesheets/bootstrap.scss';
+@import '../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap.scss';
 // endbower
 
 .browsehappy {


### PR DESCRIPTION
The `ignorePath` in the `app` target is unnecessary because `bower_components` is no longer in the `app` folder, so it doesn't do anything anymore.

The `ignorePath` in `sass` target doesn't do anything either, because the generated path starts with `../../bower_components`, like in the diff.

Both of these work without `ignorePath`, I tested both `serve` and `build`.

I believe I got it right this time :wink: 
