### PR TITLE
Repair bower_components paths for jQuery, Modernizr, and Bootstrap

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -387,7 +387,7 @@ module.exports = function (grunt) {
         // reference in your app
         modernizr: {
             dist: {
-                devFile: 'bower_components/modernizr/modernizr.js',
+                devFile: 'app/bower_components/modernizr/modernizr.js',
                 outputFile: '<%%= config.dist %>/scripts/vendor/modernizr.js',
                 files: {
                     src: [

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -9,7 +9,7 @@
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
         <!-- build:css styles/vendor.css -->
         <!-- bower:css -->
-        <% if (includeBootstrap && !includeSass) { %><link rel="stylesheet" href="../bower_components/bootstrap/dist/css/bootstrap.css"><% } %>
+        <% if (includeBootstrap && !includeSass) { %><link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.css"><% } %>
         <!-- endbower -->
         <!-- endbuild -->
         <!-- build:css(.tmp) styles/main.css -->

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -79,7 +79,7 @@
 
         <!-- build:js scripts/vendor.js -->
         <!-- bower:js -->
-        <script src="../bower_components/jquery/dist/jquery.js"></script>
+        <script src="bower_components/jquery/dist/jquery.js"></script>
         <!-- endbower -->
         <!-- endbuild -->
 


### PR DESCRIPTION
Unless there is a plan to move "bower_components" to outside of "app" then this pull request should fix issues with jQuery and Modernizr's path's producing empty files/errors with building.
