### PR TITLE
Make the bootstrap font path relative

### DIFF
--- a/app/templates/main.scss
+++ b/app/templates/main.scss
@@ -1,4 +1,4 @@
-<% if (includeBootstrap) { %>$icon-font-path: "/bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/";
+<% if (includeBootstrap) { %>$icon-font-path: "../bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/";
 
 // bower:scss
 @import '../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap.scss';


### PR DESCRIPTION
The current Bootstrap font path only works for projects in root directories. I recommend making the path relative instead of absolute so that it will also work when projects are deployed to subdirectories.
