### PR TITLE
closes #342 - remove loadPath & includePath.

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -190,14 +190,6 @@ module.exports = function (grunt) {
 
         // Compiles Sass to CSS and generates necessary files if requested
         sass: {
-            options: {<% if (includeLibSass) { %>
-                includePaths: [
-                    'bower_components'
-                ]<% } if (includeRubySass) { %>
-                loadPath: [
-                    'bower_components'
-                ]<% } %>
-            },
             dist: {
                 files: [{
                     expand: true,

--- a/app/templates/main.scss
+++ b/app/templates/main.scss
@@ -1,4 +1,4 @@
-<% if (includeBootstrap) { %>$icon-font-path: "/bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/";
+<% if (includeBootstrap) { %>$icon-font-path: "../../bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/";
 
 // bower:scss
 @import '../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap.scss';


### PR DESCRIPTION
We recently removed `loadPath` from the Gulp generator to avoid unnecessary magic and confusion. Should we kill it here, too?
