### PR TITLE
Fix location for Bootstrap fonts with Sass and CSS

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -195,7 +195,7 @@ module.exports = function (grunt) {
                 files: [{
                     expand: true,
                     cwd: '<%%= config.app %>/styles',
-                    src: ['*.scss'],
+                    src: ['*.{scss,sass}'],
                     dest: '.tmp/styles',
                     ext: '.css'
                 }]
@@ -204,7 +204,7 @@ module.exports = function (grunt) {
                 files: [{
                     expand: true,
                     cwd: '<%%= config.app %>/styles',
-                    src: ['*.scss'],
+                    src: ['*.{scss,sass}'],
                     dest: '.tmp/styles',
                     ext: '.css'
                 }]
@@ -360,11 +360,11 @@ module.exports = function (grunt) {
                 }<% if (includeBootstrap) { %>, {
                     expand: true,
                     dot: true,<% if (includeSass) { %>
-                    cwd: '.',
-                    src: ['bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/*.*'],<% } else { %>
-                    cwd: 'bower_components/bootstrap/dist',
-                    src: ['fonts/*.*'],<% } %>
-                    dest: '<%%= config.dist %>'
+                    cwd: 'bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/',
+                    src: ['*.*'],<% } else { %>
+                    cwd: 'bower_components/bootstrap/dist/fonts/',
+                    src: ['*.*'],<% } %>
+                    dest: '<%%= config.dist %>/styles/fonts'
                 }<% } %>]
             },
             styles: {

--- a/app/templates/main.scss
+++ b/app/templates/main.scss
@@ -1,4 +1,4 @@
-<% if (includeBootstrap) { %>$icon-font-path: "../../bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/";
+<% if (includeBootstrap) { %>$icon-font-path: "../styles/fonts/";
 
 // bower:scss
 @import '../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap.scss';


### PR DESCRIPTION
The entire bootstrap-sass fonts folder path was being copied across, now it copies just the files, it works with regular bootstrap as well.
