### PR TITLE
Clean up vendor.css build comments

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -6,12 +6,12 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
         <link rel="shortcut icon" href="/favicon.ico">
-        <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+        <!-- Place favicon.ico and apple-touch-icon.png in the root directory --><% if (includeBootstrap && !includeSass) { %>
         <!-- build:css styles/vendor.css -->
         <!-- bower:css -->
-        <% if (includeBootstrap && !includeSass) { %><link rel="stylesheet" href="../bower_components/bootstrap/dist/css/bootstrap.css"><% } %>
+        <link rel="stylesheet" href="../bower_components/bootstrap/dist/css/bootstrap.css">
         <!-- endbower -->
-        <!-- endbuild -->
+        <!-- endbuild --><% } %>
         <!-- build:css(.tmp) styles/main.css -->
         <link rel="stylesheet" href="styles/main.css">
         <!-- endbuild --><% if (includeModernizr) { %>


### PR DESCRIPTION
Keeps from creating unneeded usemin comments, which in turn keeps grunt from trying to process the file
