### PR TITLE
bootstrap.scss path is wrong in main.scss

### DIFF
--- a/app/templates/main.scss
+++ b/app/templates/main.scss
@@ -1,7 +1,7 @@
-<% if (includeBootstrap) { %>$icon-font-path: "../../bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/";
+<% if (includeBootstrap) { %>$icon-font-path: "../bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/";
 
 // bower:scss
-@import '../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap.scss';
+@import '../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap.scss';
 // endbower
 
 .browsehappy {


### PR DESCRIPTION
An error occurred while After running the grunt task.

$ grunt serve

...

Running "concurrent:server" (concurrent) task

```
Running "copy:styles" (copy) task


Done, without errors.


Execution Time (2014-05-10 05:29:26 UTC)
loading tasks  6ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 38%
copy:styles    9ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 56%
Total 16ms
    Warning: Syntax error: File to import not found or unreadable: ../../bower_components/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap.scss.
              Load paths:
                /Users/../Projects/sample
                /Users/../Projects/sample/app/styles
                /Users/../Projects/sample/bower_components
        on line 4 of app/styles/main.scss
  Use --trace for backtrace. Use --force to continue.

    Aborted due to warnings.
```

Execution Time (2014-05-10 05:29:24 UTC)
concurrent:server  1.9s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 99%
Total 1.9s

$ 
