### PR TITLE
Bumping grunt-contrib-imagemin version and adding javascript image revving

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -266,10 +266,16 @@ module.exports = function (grunt) {
         // Performs rewrites based on rev and the useminPrepare configuration
         usemin: {
             options: {
-                assetsDirs: ['<%%= config.dist %>', '<%%= config.dist %>/images']
+                assetsDirs: ['<%%= config.dist %>', '<%%= config.dist %>/images'],
+                patterns: {
+                    js: [
+                        [/(images\/.*?\.(?:gif|jpeg|jpg|png|webp))/gm, 'Update the JS to reference our revved images']
+                    ]
+                }
             },
             html: ['<%%= config.dist %>/{,*/}*.html'],
-            css: ['<%%= config.dist %>/styles/{,*/}*.css']
+            css: ['<%%= config.dist %>/styles/{,*/}*.css'],
+            js: ['<%= config.dist %>/scripts/*.js']
         },
 
         // The following *-min tasks produce minified files in the dist folder

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -16,7 +16,7 @@
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-htmlmin": "~0.2.0",
     "grunt-bower-install": "~1.4.0",
-    "grunt-contrib-imagemin": "~0.6.0",
+    "grunt-contrib-imagemin": "~0.7.0",
     "grunt-contrib-watch": "~0.6.1",<% if (testFramework === 'jasmine') { %>
     "grunt-contrib-jasmine": "~0.6.3",<% } %>
     "grunt-rev": "~0.1.0",


### PR DESCRIPTION
First pull request, so bear with me if it should have been two separate pull requests due to the two commits. I could have squashed them, but it seemed more logical to keep them separate.

Imagemin was broken on Windows (at least) in 0.4.9, bumped to version 0.7.0 (from 0.6.0). Tested on OS X, Windows and Heroku (Linux). 

I've also added usemin to JavaScript files so that when one generates html in JS it still works afterwards. There is a pattern match and it should only grab URI's that are legitimate. 

All tests pass, and no new complaints from JSHint. 
