### PR TITLE
add --allow-remote option to serve task

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -414,7 +414,7 @@ module.exports = function (grunt) {
     });
 
 
-    grunt.registerTask('serve', function (target) {
+    grunt.registerTask('serve', 'start the server and preview your app, --allow-remote for remote access', function (target) {
         if (grunt.option('allow-remote')) {
             grunt.config.set('connect.options.hostname', '0.0.0.0');
         }

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -415,6 +415,9 @@ module.exports = function (grunt) {
 
 
     grunt.registerTask('serve', function (target) {
+        if (grunt.option('allow-remote')) {
+            grunt.config.set('connect.options.hostname', '0.0.0.0');
+        }
         if (target === 'dist') {
             return grunt.task.run(['build', 'connect:dist:keepalive']);
         }

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ For more information on what `generator-webapp` can do for you, take a look at t
 
 - Install: `npm install -g generator-webapp`
 - Run: `yo webapp`
-- Run `grunt` for building and `grunt serve` for preview[*](#serve-note)
+- Run `grunt` for building and `grunt serve` for preview[*](#serve-note). `--allow-remote` option for remote access.
 
 
 #### Third-Party Dependencies


### PR DESCRIPTION
Now users can run `grunt serve --allow-remote` to start a remote accessible server.
I've test it manually, but I've no idea how to modify test.js to cover this...
