### PR TITLE
Fix bootstrap fonts directory for dist

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -363,7 +363,7 @@ module.exports = function (grunt) {
                     cwd: 'bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/',<% } else { %>
                     cwd: 'bower_components/bootstrap/dist/fonts/',<% } %>
                     src: ['*.*'],
-                    dest: '<%%= config.dist %>/styles/fonts'
+                    dest: '<%%= config.dist %>/fonts'
                 }<% } %>]
             },
             styles: {


### PR DESCRIPTION
Fixes the issue of sass-less bootstrap's fonts folder being under "styles/fonts", but the css file references "../fonts"
