### PR TITLE
Usemin for all .html files, not just index.html

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -260,7 +260,7 @@ module.exports = function (grunt) {
             options: {
                 dest: '<%%= config.dist %>'
             },
-            html: '<%%= config.app %>/index.html'
+            html: '<%%= config.app %>/*.html'
         },
 
         // Performs rewrites based on rev and the useminPrepare configuration


### PR DESCRIPTION
Why just index.html?
