### PR TITLE
Remove test/bower_components from gitignore list

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -3,4 +3,3 @@ dist
 .tmp<% if (includeSass) { %>
 .sass-cache<% } %>
 bower_components
-test/bower_components


### PR DESCRIPTION
No need to specify test/bower_components in gitignore, if bower_components folder was added without slash `"/"`. From git docs:

> If the pattern does not contain a slash '/', Git treats it as a shell glob pattern and checks for a match against the pathname relative to the location of the .gitignore file (relative to the toplevel of the work tree if not from a .gitignore file).
