### PR TITLE
Sensible autoprefixer defaults. #397

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -221,7 +221,7 @@ module.exports = function (grunt) {
     // Add vendor prefixed styles
     autoprefixer: {
       options: {
-        browsers: ['last 1 version']
+        browsers: ['> 1%', 'last 2 versions', 'Firefox ESR', 'Opera 12.1']
       },
       dist: {
         files: [{


### PR DESCRIPTION
The whole reason to use autoprefixer is to support/generate vendor prefixes for the older browsers, so we should be using some sensible defaults to catch more than just the last version. (#397)
