### PR TITLE
"../"-regex also matched the ts/ of bower_components/ - therefore removing it

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -236,7 +236,7 @@ module.exports = function (grunt) {
     // Automatically inject Bower components into the HTML file
     wiredep: {
       app: {
-        ignorePath: new RegExp('^<%%= config.app %>/|../'),
+        ignorePath: /^<%= config.app %>\/|\.\.\//,
         src: ['<%%= config.app %>/index.html']<% if (includeBootstrap) { %>,<% if (includeSass) { %>
         exclude: ['bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap.js']<% } else { %>
         exclude: ['bower_components/bootstrap/dist/js/bootstrap.js']<% } } %>


### PR DESCRIPTION
The `ignorePath` in the wiredep configuration matched the ending of the bower_components/ folder, removing the "ts/":

``` html
<script src="bower_componenjquery/dist/jquery.js"></script>
```

which obviously should be:

``` html
<script src="bower_components/jquery/dist/jquery.js"></script>
```

discussed here: stephenplusplus/grunt-wiredep#87 - thanks to @stephenplusplus for pointing out :grin: 
