### PR TITLE
exclude 'vendor' folder from bootstrap assets path

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -238,7 +238,7 @@ module.exports = function (grunt) {
       app: {
         ignorePath: /^<%= config.app %>\/|\.\.\//,
         src: ['<%%= config.app %>/index.html']<% if (includeBootstrap) { %>,<% if (includeSass) { %>
-        exclude: ['bower_components/bootstrap-sass-official/vendor/assets/javascripts/bootstrap.js']<% } else { %>
+        exclude: ['bower_components/bootstrap-sass-official/assets/javascripts/bootstrap.js']<% } else { %>
         exclude: ['bower_components/bootstrap/dist/js/bootstrap.js']<% } } %>
       }<% if (includeSass) { %>,
       sass: {
@@ -375,7 +375,7 @@ module.exports = function (grunt) {
               %>bower_components/bootstrap/dist<%
             } %>',
           src: '<% if (includeSass) {
-              %>bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/*<%
+              %>bower_components/bootstrap-sass-official/assets/fonts/bootstrap/*<%
             } else {
               %>fonts/*<%
             } %>',

--- a/app/templates/main.scss
+++ b/app/templates/main.scss
@@ -1,6 +1,6 @@
-<% if (includeBootstrap) { %>$icon-font-path: "../bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap/";
+<% if (includeBootstrap) { %>$icon-font-path: "../bower_components/bootstrap-sass-official/assets/fonts/bootstrap/";
 // bower:scss
-@import "bootstrap-sass-official/vendor/assets/stylesheets/bootstrap.scss";
+@import "bootstrap-sass-official/assets/stylesheets/bootstrap.scss";
 // endbower
 
 .browsehappy {


### PR DESCRIPTION
As is in bootstrap 3.2 sass version there is no more vendor folder inside assets
