### PR TITLE
Fix Sass sourcemap warning

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -195,7 +195,6 @@ module.exports = function (grunt) {
         sourceMap: true,
         includePaths: ['bower_components']
         <% } else { %>
-        sourcemap: true,
         loadPath: 'bower_components'
       <% } %>},
       dist: {


### PR DESCRIPTION
The sourcemap option defaults to `true`.
