### PR TITLE
'grunt build' now properly writes bower components to vendor files

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -161,7 +161,7 @@ module.exports = yeoman.generators.Base.extend({
           bs + 'collapse.js',
           bs + 'tab.js'
         ],
-        searchPath: '.'
+        searchPath: 'app'
       });
     }
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width">
     <link rel="shortcut icon" href="/favicon.ico">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
-    <!-- build:css(.) styles/vendor.css -->
+    <!-- build:css(app) styles/vendor.css -->
     <!-- bower:css -->
     <% if (includeBootstrap && !includeSass) { %><link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.css"><% } %>
     <!-- endbower -->
@@ -77,7 +77,7 @@
     </div>
     <% } %>
 
-    <!-- build:js(.) scripts/vendor.js -->
+    <!-- build:js(app) scripts/vendor.js -->
     <!-- bower:js -->
     <!-- endbower -->
     <!-- endbuild -->


### PR DESCRIPTION
The usemin blocks for vendor.css and vendor.js were pointed at '(.)' instead of '(app)', which resulted in bower components not being written
to these files.
