### PR TITLE
Added --on option to grunt serve to support selection of browser on star...

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -440,6 +440,16 @@ module.exports = function (grunt) {
     if (grunt.option('allow-remote')) {
       grunt.config.set('connect.options.hostname', '0.0.0.0');
     }
+	if (grunt.option('on')) {
+		//iexplore, chrome, firefox, etc.
+		grunt.log.write('Starting with browser ' + grunt.option('on'));
+
+		if (target === 'dist') {
+			grunt.config.set('connect.dist.options.open', { appName: grunt.option('on') });
+		} else {
+			grunt.config.set('connect.livereload.options.open', { appName: grunt.option('on') });
+		}
+	}
     if (target === 'dist') {
       return grunt.task.run(['build', 'connect:dist:keepalive']);
     }


### PR DESCRIPTION
Hi

i've added a useful option to "grunt serve" to select the browser to start with.
eg. grunt serve --on iexplore

could be useful while developing web apps..

cheers,
Sandro
