### PR TITLE
`.jshintrc`: remove deprecated options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -10,7 +10,5 @@
 	"newcap": true,
 	"noarg": true,
 	"undef": true,
-	"strict": false,
-	"trailing": true,
-	"smarttabs": true
+	"strict": false
 }


### PR DESCRIPTION
JSHint options `trailing` and `smarttabs` are deprecated with jshint v2.5. See https://github.com/jshint/jshint/releases/tag/2.5.0
