### PR TITLE
add map option in autoprefixer task so that sourceMappingURL is not removed

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -222,7 +222,11 @@ module.exports = function (grunt) {
     // Add vendor prefixed styles
     autoprefixer: {
       options: {
-        browsers: ['> 1%', 'last 2 versions', 'Firefox ESR', 'Opera 12.1']
+        browsers: ['> 1%', 'last 2 versions', 'Firefox ESR', 'Opera 12.1']<% if (includeSass) { %>,
+        map: {
+          prev: '.tmp/styles/'
+        }
+        <% } %>
       },
       dist: {
         files: [{


### PR DESCRIPTION
add map option in autoprefixer task so that sourceMappingURL is not removed

fixes #455
