### PR TITLE
custom port for js files livereload

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -48,7 +48,7 @@ module.exports = function (grunt) {
         files: ['<%%= config.app %>/scripts/{,*/}*.js'],
         tasks: ['jshint'],
         options: {
-          livereload: true
+          livereload: '<%%= connect.options.livereload %>'
         }
       },
       jstest: {


### PR DESCRIPTION
Make the watch task use livereload for js files on the same port  as defined in `connect.options.livereload`.  
I tried to change the port of the livereload task (in order to have 2 projects running simultaneous) and it failed saying that _Port 35729 is already in use by another process._, which shouldn't have been true since I've updated the livereload task to listen to a different port.  
The issue seems to have been from the  watch.js subtask that had livereload enabled on the default port (which is indeed 35729) regardless of the livereload port specified in `connect.options.livereload`.
