### PR TITLE
Suggest setting removeRedundantAttributes to false [htmlmin:dist]

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -323,7 +323,7 @@ module.exports = function (grunt) {
           removeCommentsFromCDATA: true,
           removeEmptyAttributes: true,
           removeOptionalTags: true,
-          // setting removeRedundantAttributes to true will impact styles with attribute selectors
+          // true would impact styles with attribute selectors
           removeRedundantAttributes: false,
           useShortDoctype: true
         },

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -323,7 +323,10 @@ module.exports = function (grunt) {
           removeCommentsFromCDATA: true,
           removeEmptyAttributes: true,
           removeOptionalTags: true,
-          removeRedundantAttributes: true,
+          // removing redundant attributes from input fields removes attributes that could be styled
+          // such as type="text", placeholder etc.. I would suggest setting removeRedundantAttributes
+          // to false as leaving it set to true might cause undesired results when distributing/running build
+          removeRedundantAttributes: false,
           useShortDoctype: true
         },
         files: [{

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -323,9 +323,7 @@ module.exports = function (grunt) {
           removeCommentsFromCDATA: true,
           removeEmptyAttributes: true,
           removeOptionalTags: true,
-          // removing redundant attributes from input fields removes attributes that could be styled
-          // such as type="text", placeholder etc.. I would suggest setting removeRedundantAttributes
-          // to false as leaving it set to true might cause undesired results when distributing/running build
+          // setting removeRedundantAttributes to true will impact styles with attribute selectors
           removeRedundantAttributes: false,
           useShortDoctype: true
         },


### PR DESCRIPTION
Removing redundant attributes from input fields removes attributes that could be styled such as type="text", placeholder etc.. I would suggest setting removeRedundantAttributes to false as leaving it set to true might cause undesired results when distributing/running build
