### PR TITLE
Fix generated index.html indent

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -2,6 +2,18 @@
 var join = require('path').join;
 var yeoman = require('yeoman-generator');
 var chalk = require('chalk');
+var _ = require('underscore');
+
+var appendConvert4To2 = function () {
+  var args = _.toArray(arguments);
+
+  // force convert indent size from 4 to 2
+  if (args.length > 2 && args[2], _.isString(args[2])) {
+    args[2] = args[2].replace(/^        /gm, '    ');
+  }
+
+  return this._append.apply(this, args);
+};
 
 module.exports = yeoman.generators.Base.extend({
   constructor: function () {
@@ -23,6 +35,11 @@ module.exports = yeoman.generators.Base.extend({
     this.coffee = this.options.coffee;
 
     this.pkg = require('../package.json');
+
+    // override append method
+    // force convert indent size from 4 to 2
+    this._append = this.append;
+    this.append = appendConvert4To2;
   },
 
   askFor: function () {

--- a/app/index.js
+++ b/app/index.js
@@ -10,6 +10,21 @@ var appendConvert4To2 = function () {
   // force convert indent size from 4 to 2
   if (args.length > 2 && args[2], _.isString(args[2])) {
     args[2] = args[2].replace(/^        /gm, '    ');
+
+    // before
+    // ----------
+    //   </body>
+    // ----------
+    // append script tag
+    //
+    // after
+    //
+    // ----------
+    //     <script...
+    //
+    //   </body>
+    // ----------
+    args[2] += '\n  ';
   }
 
   return this._append.apply(this, args);


### PR DESCRIPTION
generator-webapp was change indent from 4 to 2 at e960a8ebb3b0b61f5efe7ab3f30645ff0cffaf13.

However, index.html has few 4 indent. This is a patch to change this to 2 indent.

before

```
$ npm install -g generator-webapp@0.5.1
$ mkdir webapp1; cd $_
$ yo webapp
$ tail app/index.html 
        <script src="bower_components/bootstrap/js/scrollspy.js"></script>
        <script src="bower_components/bootstrap/js/collapse.js"></script>
        <script src="bower_components/bootstrap/js/tab.js"></script>
        <!-- endbuild -->

        <!-- build:js({app,.tmp}) scripts/main.js -->
        <script src="scripts/main.js"></script>
        <!-- endbuild -->
</body>
</html>
```

after

```
$ tail app/index.html 
    <script src="bower_components/bootstrap/js/tab.js"></script>
    <!-- endbuild -->


    <!-- build:js({app,.tmp}) scripts/main.js -->
    <script src="scripts/main.js"></script>
    <!-- endbuild -->

  </body>
</html>
```
