### PR TITLE
Fix error of Gruntfile with coffee option

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -419,12 +419,12 @@ module.exports = function (grunt) {
     // Run some tasks in parallel to speed up build process
     concurrent: {
       server: [<% if (coffee) {  %>
-        'coffee:dist'<% } %><% if (coffee && includeSass) {  %>,<% } %><% if (includeSass) { %>
+        'coffee:dist',<% } %><% if (includeSass) { %>
         'sass:server'<% } else { %>
         'copy:styles'<% } %>
       ],
       test: [<% if (coffee) { %>
-        'coffee',<% } %><% if (coffee && !includeSass) {  %>,<% } %><% if (!includeSass) { %>
+        'coffee'<% } %><% if (coffee && !includeSass) {  %>,<% } %><% if (!includeSass) { %>
         'copy:styles'<% } %>
       ],
       dist: [<% if (coffee) { %>


### PR DESCRIPTION
The `Gruntfile.js` is collapsed when generating a webapp with `--coffee` option.

``` javascript
concurrent: {
  server: [
    'coffee:dist'    // "," is missing
    'copy:styles'
  ],
  test: [
    'coffee',,       // "," is duplicated
    'copy:styles'
  ],
  ...
```

I fixed the template. Thanks.
