### PR TITLE
[WIP] Add jscs javascript validation

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -124,6 +124,10 @@ module.exports = yeoman.generators.Base.extend({
     this.copy('jshintrc', '.jshintrc');
   },
 
+  jscs: function () {
+    this.copy('jscsrc', '.jscsrc');
+  },
+
   editorConfig: function () {
     this.copy('editorconfig', '.editorconfig');
   },

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -432,7 +432,19 @@ module.exports = function (grunt) {
     }
   });
 
-  grunt.registerTask('lint', ['jshint', 'jscs']);
+  grunt.registerTask('lint', function (target) {
+    console.log(target);
+    var tasks = [
+      'jshint',
+      'jscs'
+    ];
+
+    if (target === 'newer') {
+      tasks = tasks.map(function (task) { return 'newer:' + task; });
+    }
+
+    grunt.task.run(tasks);
+  });
 
   grunt.registerTask('serve', 'start the server and preview your app', function (target) {
 
@@ -488,8 +500,7 @@ module.exports = function (grunt) {
   ]);
 
   grunt.registerTask('default', [
-    'newer:jshint',
-    'newer:jscs',
+    'lint:newer',
     'test',
     'build'
   ]);

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -55,7 +55,7 @@ module.exports = function (grunt) {
       },<% } else { %>
       js: {
         files: ['<%%= config.app %>/scripts/{,*/}*.js'],
-        tasks: ['jscheck']
+        tasks: ['lint']
       },
       jstest: {
         files: ['test/spec/{,*/}*.js'],
@@ -432,7 +432,7 @@ module.exports = function (grunt) {
     }
   });
 
-  grunt.registerTask('jscheck', ['jshint', 'jscs']);
+  grunt.registerTask('lint', ['jshint', 'jscs']);
 
   grunt.registerTask('serve', 'start the server and preview your app', function (target) {
 

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -21,17 +21,16 @@ module.exports = function (grunt) {
   // Configurable paths
   var config = {
     app: 'app',
-    dist: 'dist'
-  };
-
-  config.targets = {
-    // Validate target javascripts
-    jscheck: [
-      'Gruntfile.js',
-      '<%%= config.app %>/scripts/{,*/}*.js',
-      '!<%%= config.app %>/scripts/vendor/*',
-      'test/spec/{,*/}*.js'
-    ]
+    dist: 'dist',
+    targets: {
+      // Validate target javascripts
+      jscheck: [
+        'Gruntfile.js',
+        '<%%= config.app %>/scripts/{,*/}*.js',
+        '!<%%= config.app %>/scripts/vendor/*',
+        'test/spec/{,*/}*.js'
+      ]
+    }
   };
 
   // Define the configuration for all the tasks

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -24,6 +24,16 @@ module.exports = function (grunt) {
     dist: 'dist'
   };
 
+  config.targets = {
+    // Validate target javascripts
+    jscheck: [
+      'Gruntfile.js',
+      '<%%= config.app %>/scripts/{,*/}*.js',
+      '!<%%= config.app %>/scripts/vendor/*',
+      'test/spec/{,*/}*.js'
+    ]
+  };
+
   // Define the configuration for all the tasks
   grunt.initConfig({
 
@@ -46,7 +56,7 @@ module.exports = function (grunt) {
       },<% } else { %>
       js: {
         files: ['<%%= config.app %>/scripts/{,*/}*.js'],
-        tasks: ['jshint'],
+        tasks: ['jscheck']
       },
       jstest: {
         files: ['test/spec/{,*/}*.js'],
@@ -129,12 +139,11 @@ module.exports = function (grunt) {
         jshintrc: '.jshintrc',
         reporter: require('jshint-stylish')
       },
-      all: [
-        'Gruntfile.js',
-        '<%%= config.app %>/scripts/{,*/}*.js',
-        '!<%%= config.app %>/scripts/vendor/*',
-        'test/spec/{,*/}*.js'
-      ]
+      all: config.targets.jscheck
+    },
+    // Make sure code styles are up to par and there are no obvious mistakes
+    jscs: {
+      all: config.targets.jscheck
     },<% if (testFramework === 'mocha') { %>
 
     // Mocha testing framework configuration options
@@ -424,6 +433,7 @@ module.exports = function (grunt) {
     }
   });
 
+  grunt.registerTask('jscheck', ['jshint', 'jscs']);
 
   grunt.registerTask('serve', 'start the server and preview your app', function (target) {
 
@@ -480,6 +490,7 @@ module.exports = function (grunt) {
 
   grunt.registerTask('default', [
     'newer:jshint',
+    'newer:jscs',
     'test',
     'build'
   ]);

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -25,6 +25,7 @@
     "grunt-svgmin": "^0.4.0",
     "grunt-usemin": "^2.3.0",
     "grunt-wiredep": "^1.7.0",
+    "grunt-jscs": "^1.6.0",
     "jshint-stylish": "^0.4.0",
     "load-grunt-tasks": "^0.4.0",
     "time-grunt": "^0.4.0"

--- a/app/templates/jscsrc
+++ b/app/templates/jscsrc
@@ -1,0 +1,14 @@
+{
+  "preset": "google",
+  "requireSpacesInFunctionExpression": {
+    "beforeOpeningRoundBrace": true,
+    "beforeOpeningCurlyBrace": true
+  },
+  "disallowSpacesInAnonymousFunctionExpression": null,
+  "requireBlocksOnNewline": 1,
+  "disallowTrailingComma": true,
+  "disallowKeywordsOnNewLine": ["else"],
+  "requireSpaceAfterLineComment": true,
+  "disallowNewlineBeforeBlockStatements": true,
+  "maximumLineLength": 120
+}

--- a/test/test.js
+++ b/test/test.js
@@ -21,6 +21,8 @@ describe('Webapp generator', function () {
       '.editorconfig',
       '.gitignore',
       '.gitattributes',
+      '.jshintrc',
+      '.jscsrc',
       'package.json',
       'bower.json',
       'Gruntfile.js',


### PR DESCRIPTION
JSHint no longer report the inspection of indent. Validation that overlap with JSCS an JSHint's option seems to go been deleted.

http://jshint.com/docs/options/#indent

> Warning This option has been deprecated and will be removed in the next major release of JSHint. JSHint is limiting its scope to issues of code correctness. If you would like to enforce rules relating to code style, check out the JSCS project.

Would you add JSCS validation, not only JSHint?

[JSCS](https://github.com/jscs-dev/node-jscs) and [grunt-jscs](https://github.com/jscs-dev/grunt-jscs)
