### PR TITLE
make jasmine test framework work

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -46,7 +46,7 @@ module.exports = function (grunt) {
       },<% } else { %>
       js: {
         files: ['<%%= config.app %>/scripts/{,*/}*.js'],
-        tasks: ['jshint'],
+        tasks: ['jshint']
       },
       jstest: {
         files: ['test/spec/{,*/}*.js'],
@@ -92,8 +92,9 @@ module.exports = function (grunt) {
           open: false,
           logLevel: 'silent',
           host: 'localhost',
-          server: {
-            baseDir: ['.tmp', './test', config.app],
+          server: {<% if (testFramework === 'mocha') { %>
+            baseDir: ['.tmp', './test', config.app],<% } else if (testFramework === 'jasmine') { %>
+            baseDir: ['./'],<% } %>
             routes: {
               '/bower_components': './bower_components'
             }
@@ -150,8 +151,14 @@ module.exports = function (grunt) {
     // Jasmine testing framework configuration options
     jasmine: {
       all: {
+        src: '{<%= config.app %>,.tmp}/scripts/{,*/}*.js',
         options: {
-          specs: 'test/spec/{,*/}*.js'
+          vendor: [
+            // Your bower_components scripts
+          ],
+          specs: '{test,.tmp}/spec/{,*/}*.js',
+          helpers: '{test,.tmp}/helpers/{,*/}*.js',
+          host: 'http://<%%= browserSync.test.options.host %>:<%%= browserSync.test.options.port %>'
         }
       }
     },<% } %><% if (coffee) { %>


### PR DESCRIPTION
Previously jasmine framework cannot work without more manual configs. For coffeescript the compiled javascripts are sitting in .tmp folder. Unfortunately unlike mocha, jasmine does not read a index.html to load scripts.
