### PR TITLE
Make Babel flag default=false

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -33,7 +33,7 @@ module.exports = generators.Base.extend({
     this.option('babel', {
       desc: 'Use Babel',
       type: Boolean,
-      defaults: true
+      defaults: false
     });
 
     if (this.options['test-framework'] === 'mocha') {


### PR DESCRIPTION
As of 34453b8, Babel is now an option under the `--babel` flag. However because it is [set to true by default](https://github.com/yeoman/generator-webapp/commit/34453b839fc5c7fb2b3e2a39c12b859f912922f5#diff-2018087f584c4398b5c3a23fc0e5f9dbR21), there doesn't seem to be a way to turn it off so it's effectively compulsory. (Am I correct in this? I tried `--babel=false` and consulted the Yeoman docs, but I can't find a way to set the flag to false.)

If Babel is supposed to be optional then shouldn't it be off by default? Else use a prompt instead.
