### PR TITLE
Move underscore.string from devDependency to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "generator-jasmine": "^0.1.3",
     "generator-mocha": "^0.2.0",
     "mkdirp": "^0.5.1",
+    "underscore.string": "^3.1.1",
     "wiredep": "^2.2.2",
     "yeoman-generator": "^0.20.1",
     "yosay": "^1.0.4"
@@ -34,7 +35,6 @@
   "devDependencies": {
     "grunt-cli": "^0.1.13",
     "mocha": "*",
-    "underscore.string": "^3.1.1",
     "yeoman-assert": "^2.0.0"
   }
 }


### PR DESCRIPTION
To avoid getting

``` bash
$ yo webapp
module.js:338
    throw err;
          ^
Error: Cannot find module 'underscore.string'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/mart/.nvm/versions/node/v0.12.4/lib/node_modules/generator-webapp/app/index.js:8:10)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
```
