### PR TITLE
Reverting change to Gruntfile.js to fix broken task in generated webapp

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -192,7 +192,7 @@ module.exports = function (grunt) {
         sourceMap: true,
         sourceMapEmbed: true,
         sourceMapContents: true,
-        includePaths: ['.']
+        includePaths: ['bower_components']
       },
       dist: {
         files: [{


### PR DESCRIPTION
The generated webapp sass grunt task fails as described in issue 568.  This change fixes the issue.
