### PR TITLE
Fix "does not uses ESLint jquery environment"

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -127,6 +127,7 @@ module.exports = generators.Base.extend({
         {
           includeSass: this.includeSass,
           includeModernizr: this.includeModernizr,
+          includeJQuery: this.includeBootstrap || this.includeJQuery,
           testFramework: this.options['test-framework'],
           useBabel: this.options['babel']
         }

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -47,7 +47,8 @@
   "eslintConfig": {
     "env": {
       "node": true,
-      "browser": true<% if (testFramework === 'mocha') { %>,
+      "browser": true<% if (includeJQuery) { %>,
+      "jquery": true<% } if (testFramework === 'mocha') { %>,
       "mocha": true<% } else if (testFramework === 'jasmine') { %>,
       "jasmine": true<% } %>
     },

--- a/test/jquery.js
+++ b/test/jquery.js
@@ -19,6 +19,10 @@ describe('jquery', function () {
     it('adds the bower dependency', function () {
       assert.fileContent('bower.json', '"jquery"');
     });
+
+    it('uses the eslint environment', function () {
+      assert.fileContent('package.json', '"jquery"');
+    });
   });
 
   describe('off', function () {
@@ -35,6 +39,10 @@ describe('jquery', function () {
 
     it('doesn\'t add the bower dependency', function () {
       assert.noFileContent('bower.json', '"jquery"');
+    });
+
+    it('doesn\'nt uses the ESLint environment', function () {
+      assert.noFileContent('package.json', '"jquery"');
     });
   });
 });


### PR DESCRIPTION
There is no "jquery" to ESLint rules of the generated "package.json".

``` json
  "eslintConfig": {
    "env": {
      "node": true,
      "browser": true,
      "mocha": true
    },
    "rules": {
      "quotes": [
        2,
        "single"
      ]
    }
  }
```

eslint task is an error to use the "$".

``` javascript
// jshint devel:true
console.log($('h1').text());
```

Run `grunt eslint`.

```
$ grunt eslint
Running "eslint:target" (eslint) task

app/scripts/main.js
  2:12  error  "$" is not defined  no-undef

✖ 1 problem (1 error, 0 warnings)

Warning: Task "eslint:target" failed. Use --force to continue.

Aborted due to warnings.


Execution Time (2015-08-04 06:32:59 UTC)
loading tasks         174ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 27%
loading grunt-eslint  276ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 42%
eslint:target         206ms  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 31%
Total 656ms
```
