### PR TITLE
Update eslint to new version

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -59,6 +59,10 @@
       "quotes": [
         2,
         "single"
+      ],
+      "indent": [
+        2,
+        2
       ]
     }
   }

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -19,7 +19,7 @@
 <% } -%>
     "grunt-contrib-uglify": "^0.8.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-eslint": "^16.0.0",
+    "grunt-eslint": "^17.0.0",
     "grunt-filerev": "^2.2.0",
 <% if (testFramework === 'mocha') { -%>
     "grunt-mocha": "^0.4.12",
@@ -45,6 +45,9 @@
     "test": "grunt test"
   },
   "eslintConfig": {
+    "extends": [
+      "eslint:recommended"
+    ],
     "env": {
       "node": true,
       "browser": true<% if (includeJQuery) { %>,

--- a/app/templates/main.js
+++ b/app/templates/main.js
@@ -1,2 +1,1 @@
-// jshint devel:true
-console.log('\'Allo \'Allo!');
+console.log('\'Allo \'Allo!'); // eslint-disable-line no-console

--- a/test/eslint.js
+++ b/test/eslint.js
@@ -20,6 +20,10 @@ describe('eslint', function () {
     assert.fileContent('package.json', 'eslintConfig');
   });
 
+  it('adds eslint recommended rule', function () {
+    assert.fileContent('package.json', 'eslint:recommended');
+  });
+
   it('adds Grunt task', function () {
     assert.fileContent('Gruntfile.js', 'eslint');
   });


### PR DESCRIPTION
[ESLint 1.0.0 released](http://eslint.org/blog/2015/07/eslint-1.0.0-released/). generator-webapp use eslint@0.24.1.

Update ESLint to major release.
- All of the validation is disabled in eslint@1.0.0. To enable the recommended settings of ESLint.
- Used the "eslint-disable-line" instead of "jshint:devel true"
