### PR TITLE
Fix twice run test with babel

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -149,12 +149,20 @@ module.exports = function (grunt) {
     // Jasmine testing framework configuration options
     jasmine: {
       all: {
+<% if (useBabel) { -%>
+        src: '.tmp/scripts/{,*/}.js',
+<% } else { -%>
         src: '{<%%= config.app %>,.tmp}/scripts/{,*/}*.js',
+<% } -%>
         options: {
           vendor: [
             // Your bower_components scripts
           ],
+<% if (useBabel) { -%>
+          specs: '.tmp/spec/{,*/}*.js',
+<% } else { -%>
           specs: '{test,.tmp}/spec/{,*/}*.js',
+<% } -%>
           helpers: '{test,.tmp}/helpers/{,*/}*.js',
           host: 'http://<%%= browserSync.test.options.host %>:<%%= browserSync.test.options.port %>'
         }


### PR DESCRIPTION
`grunt test` runs twice with babel and jasmine.

As it follows.

```
$ yo webapp --test-framework=jasmine
...

$ grunt test

...

Running "jasmine:all" (jasmine) task                                     [8/562]
Testing jasmine specs via PhantomJS


log: 'Allo 'Allo!

log: 'Allo 'Allo!
 Give it some context
   maybe a bit more context here
     ✓ should run here few assertions
 Give it some context
   maybe a bit more context here
     ✓ should run here few assertions

2 specs in 0.011s.
>> 0 failures

Done, without errors.

...
```
