### PR TITLE
Add eslint es6 env

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -50,7 +50,8 @@
     ],
     "env": {
       "node": true,
-      "browser": true<% if (includeJQuery) { %>,
+      "browser": true<% if (useBabel) { %>,
+      "es6": true<% } if (includeJQuery) { %>,
       "jquery": true<% } if (testFramework === 'mocha') { %>,
       "mocha": true<% } else if (testFramework === 'jasmine') { %>,
       "jasmine": true<% } %>

--- a/test/babel.js
+++ b/test/babel.js
@@ -16,6 +16,10 @@ describe('babel', function () {
     assert.fileContent('package.json', 'babel');
   });
 
+  it('adds the es6 eslint en', function () {
+    assert.fileContent('package.json', '"es6": true');
+  });
+
   it('adds the Grunt task', function () {
     assert.fileContent('Gruntfile.js', 'babel');
   });

--- a/test/babel.js
+++ b/test/babel.js
@@ -16,7 +16,7 @@ describe('babel', function () {
     assert.fileContent('package.json', 'babel');
   });
 
-  it('adds the es6 eslint en', function () {
+  it('adds the es6 eslint env', function () {
     assert.fileContent('package.json', '"es6": true');
   });
 


### PR DESCRIPTION
When you enable the babel, add ESLint es6 env to package.json.
