### PR TITLE
Fix for usemin JS path that ignores Babel transpilation

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -91,7 +91,7 @@
     <!-- endbuild -->
     <% } %>
 
-    <!-- build:js scripts/main.js -->
+    <!-- build:js(.tmp) scripts/main.js -->
     <script src="scripts/main.js"></script>
     <!-- endbuild -->
 


### PR DESCRIPTION
When running `grunt build`, `grunt-usemin` builds a flow for .js files starting with `scripts` directory that contains not transpiled ES6 code. 
The transpilation (`grunt babel` task) puts transpiled files into `.tmp` directory. It happens before the first step in js flow (`concat`) is run.
Thus, the transpilation works fine, but it's result is ignored and not transpiled files are used in `usemin` flow that ends up in target `dist` directory.

The fix changes the working directory where `usemin` starts its flow to the destination directory of Babel transpilation.

Fixes #580.
