### PR TITLE
Fix test helper's bug with babel

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -41,7 +41,10 @@ module.exports = function (grunt) {
         tasks: ['babel:dist']
       },
       babelTest: {
-        files: ['test/spec/{,*/}*.js'],
+        files: [
+          'test/spec/{,*/}*.js',
+          'test/helpers/{,*/}*.js'
+        ],
         tasks: ['babel:test', 'test:watch']
       },<% } else { %>
       js: {
@@ -166,7 +169,11 @@ module.exports = function (grunt) {
 <% } else { -%>
           specs: '{test,.tmp}/spec/{,*/}*.js',
 <% } -%>
+<% if (useBabel) { -%>
+          helpers: '.tmp/helpers/{,*/}*.js',
+<% } else { -%>
           helpers: '{test,.tmp}/helpers/{,*/}*.js',
+<% } -%>
           host: 'http://<%%= browserSync.test.options.host %>:<%%= browserSync.test.options.port %>'
         }
       }
@@ -191,7 +198,10 @@ module.exports = function (grunt) {
         files: [{
           expand: true,
           cwd: 'test/spec',
-          src: '{,*/}*.js',
+          src: [
+            '{,*/}*.js',
+            '../helpers/{,*/}*.js'
+          ],
           dest: '.tmp/spec',
           ext: '.js'
         }]

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -195,11 +195,14 @@ module.exports = function (grunt) {
         files: [{
           expand: true,
           cwd: 'test/spec',
-          src: [
-            '{,*/}*.js',
-            '../helpers/{,*/}*.js'
-          ],
+          src: '{,*/}*.js',
           dest: '.tmp/spec',
+          ext: '.js'
+        }, {
+          expand: true,
+          cwd: 'test/helpers',
+          src: '{,*/}*.js',
+          dest: '.tmp/helpers',
           ext: '.js'
         }]
       }

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -41,10 +41,7 @@ module.exports = function (grunt) {
         tasks: ['babel:dist']
       },
       babelTest: {
-        files: [
-          'test/spec/{,*/}*.js',
-          'test/helpers/{,*/}*.js'
-        ],
+        files: 'test/{spec,helpers}/{,*/}*.js',
         tasks: ['babel:test', 'test:watch']
       },<% } else { %>
       js: {


### PR DESCRIPTION
Fix test helper's babel with babel.
- Cannot build `test/helpers/*.js` with babel.
- Cannot restart test on changed `test/helpers/*.js` with `grunt serve`.
