### PR TITLE
add browserSync watchOptions.ignored

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -68,7 +68,10 @@ module.exports = function (grunt) {
     browserSync: {
       options: {
         notify: false,
-        background: true
+        background: true,
+        watchOptions: {
+          ignored: ''
+        }
       },
       livereload: {
         options: {


### PR DESCRIPTION
@silvenon we need set browserSync [watchOptions.ignored](http://www.browsersync.io/docs/options/#option-watchOptions) to prevent the js/css reload issues.
the problem was browserSync ignores files/folders that start with dot by default ( see https://github.com/BrowserSync/browser-sync/blob/master/lib/file-watcher.js#L15 )

fixes #585, #579 , #603 
