### PR TITLE
Add deprecation notice

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,12 @@
 
 [Yeoman](http://yeoman.io) generator that scaffolds out a front-end web app.
 
+## Looking for New Maintainers
+
+This generator is not actively maintained because we're focusing on [generator-gulp-webapp](https://github.com/yeoman/generator-gulp-webapp), which is very similar, but uses [gulp](http://gulpjs.com) instead of Grunt.
+
+We would be happy to take on new maintainers and will still be around for merging PRs.
+
 ![](http://i.imgur.com/uKTT2Hj.png)
 
 ## Features


### PR DESCRIPTION
@sindresorhus sounds good?

I'm not sure about Yeoman's views on Grunt vs. gulp, I don't want to be too opinionated. Last time I checked it's this:

> The Yeoman team don't have any plans on dropping our support for Grunt at all. On the contrary, we feel that both Grunt and Gulp can happily co-exist and hope to support both communities with some automation tooling as best we can.

But that seems dated.

Refs #567.
