### PR TITLE
Fix errors on grunt build task

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -298,9 +298,9 @@ module.exports = function (grunt) {
           dest: '<%%= config.dist %>/images'
         },{
           expand: true,
-          cwd: '<%%= config.app %%>',
+          cwd: '<%%= config.app %>',
           src: '*.{ico,png}',
-          dest: '<%%= config.dist %%>'
+          dest: '<%%= config.dist %>'
         }]
       }
     },


### PR DESCRIPTION
On the grunt's build task, grunt was issuing the following errors:

```
Running "useminPrepare:html" (useminPrepare) task
Warning: An error occurred while processing a template (Unexpected token )). Use --force to continue.
```

and later:

```
Running "imagemin:dist" (imagemin) task
Warning: An error occurred while processing a template (Unexpected token )). Used --force, continuing.
```

The bug seems to have been caused by additional '%' characters added to the closing template
stings on the imagemin task in the gruntfile.

Resolves: #632
